### PR TITLE
feat: detect Electron, Setapp, JetBrains Toolbox, and Adobe CC apps

### DIFF
--- a/cmd/updater/check.go
+++ b/cmd/updater/check.go
@@ -73,6 +73,8 @@ func discoverApps() ([]*app.App, error) {
 	dirs := []string{
 		"/Applications",
 		filepath.Join(home, "Applications"),
+		"/Applications/Setapp",
+		filepath.Join(home, "Applications", "Setapp"),
 	}
 
 	apps, err := app.Discover(dirs...)
@@ -104,7 +106,7 @@ func macOSSystemApp() *app.App {
 		Name:     "macOS",
 		BundleID: "com.apple.macOS",
 		Version:  version,
-		Source:   app.Source("system"),
+		Source:   app.SourceSystem,
 	}
 }
 
@@ -238,6 +240,8 @@ func buildCheckers(runner checker.CmdRunner, githubToken string) []checker.Check
 		checker.NewGitHubChecker(nil, "", githubToken),
 		checker.NewSystemChecker(runner),
 		checker.NewBrewFormulaChecker(runner),
+		checker.NewElectronChecker(nil),
+		checker.NewManagedChecker(),
 		checker.NewBrewInfoChecker(runner), // fallback: any app with a CaskName
 	}
 }
@@ -383,6 +387,8 @@ func cliSourceName(source string) string {
 		return "homebrew"
 	case "formula":
 		return "formula"
+	case "electron", "setapp", "toolbox", "adobe":
+		return source
 	default:
 		return source
 	}

--- a/cmd/updater/check.go
+++ b/cmd/updater/check.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"sync"
 	"text/tabwriter"
@@ -39,6 +40,14 @@ func runCheck(cmd *cobra.Command, args []string) error {
 	}
 
 	runner := &checker.RealCmdRunner{}
+
+	formulaApps, err := discoverBrewFormulae(ctx, runner)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "warning: could not discover brew formulae: %v\n", err)
+	} else {
+		apps = append(apps, formulaApps...)
+	}
+
 	apps, err = enrichApps(ctx, apps, cfg, runner)
 	if err != nil {
 		return err
@@ -97,6 +106,33 @@ func macOSSystemApp() *app.App {
 		Version:  version,
 		Source:   app.Source("system"),
 	}
+}
+
+// discoverBrewFormulae creates synthetic App entries for each installed Homebrew formula.
+func discoverBrewFormulae(ctx context.Context, runner checker.CmdRunner) ([]*app.App, error) {
+	formulae, err := checker.ListInstalledFormulae(ctx, runner)
+	if err != nil {
+		return nil, err
+	}
+
+	names := make([]string, 0, len(formulae))
+	for name := range formulae {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	apps := make([]*app.App, 0, len(formulae))
+	for _, name := range names {
+		apps = append(apps, &app.App{
+			Name:             name,
+			BundleID:         "homebrew.formula." + name,
+			Version:          formulae[name],
+			Source:           app.SourceBrewFormula,
+			FormulaName:      name,
+			InstalledViaBrew: true,
+		})
+	}
+	return apps, nil
 }
 
 // enrichApps applies config mappings and cross-references with brew casks
@@ -201,6 +237,7 @@ func buildCheckers(runner checker.CmdRunner, githubToken string) []checker.Check
 		checker.NewMASChecker(runner),
 		checker.NewGitHubChecker(nil, "", githubToken),
 		checker.NewSystemChecker(runner),
+		checker.NewBrewFormulaChecker(runner),
 		checker.NewBrewInfoChecker(runner), // fallback: any app with a CaskName
 	}
 }
@@ -344,6 +381,8 @@ func cliSourceName(source string) string {
 		return "app store"
 	case "brew", "brew-info":
 		return "homebrew"
+	case "formula":
+		return "formula"
 	default:
 		return source
 	}

--- a/cmd/updater/main.go
+++ b/cmd/updater/main.go
@@ -15,7 +15,7 @@ var rootCmd = &cobra.Command{
 	Short:             "macOS app update manager",
 	Long:              "Discover installed macOS apps, check for updates, and update them from multiple sources.",
 	Version:           version,
-	CompletionOptions: cobra.CompletionOptions{DisableDefaultCmd: true},
+	CompletionOptions: cobra.CompletionOptions{HiddenDefaultCmd: true},
 	// Launch TUI when invoked with no subcommand.
 	RunE: runUI,
 }

--- a/cmd/updater/notify.go
+++ b/cmd/updater/notify.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"os"
 	"strings"
 
 	"github.com/luzhengda/updater/internal/checker"
@@ -35,6 +36,14 @@ func runNotify(cmd *cobra.Command, _ []string) error {
 	}
 
 	runner := &checker.RealCmdRunner{}
+
+	formulaApps, fErr := discoverBrewFormulae(ctx, runner)
+	if fErr != nil {
+		fmt.Fprintf(os.Stderr, "warning: could not discover brew formulae: %v\n", fErr)
+	} else {
+		apps = append(apps, formulaApps...)
+	}
+
 	apps, err = enrichApps(ctx, apps, cfg, runner)
 	if err != nil {
 		return err

--- a/cmd/updater/outdated.go
+++ b/cmd/updater/outdated.go
@@ -44,6 +44,14 @@ func runOutdated(cmd *cobra.Command, _ []string) error {
 	}
 
 	runner := &checker.RealCmdRunner{}
+
+	formulaApps, fErr := discoverBrewFormulae(ctx, runner)
+	if fErr != nil {
+		fmt.Fprintf(os.Stderr, "warning: could not discover brew formulae: %v\n", fErr)
+	} else {
+		apps = append(apps, formulaApps...)
+	}
+
 	apps, err = enrichApps(ctx, apps, cfg, runner)
 	if err != nil {
 		return err

--- a/cmd/updater/scan.go
+++ b/cmd/updater/scan.go
@@ -3,10 +3,8 @@ package main
 import (
 	"fmt"
 	"os"
-	"path/filepath"
 	"text/tabwriter"
 
-	"github.com/luzhengda/updater/internal/app"
 	"github.com/luzhengda/updater/internal/checker"
 	"github.com/spf13/cobra"
 )
@@ -24,19 +22,9 @@ func init() {
 func runScan(cmd *cobra.Command, args []string) error {
 	ctx := cmd.Context()
 
-	home, err := os.UserHomeDir()
+	apps, err := discoverApps()
 	if err != nil {
-		return fmt.Errorf("failed to get home directory: %w", err)
-	}
-
-	dirs := []string{
-		"/Applications",
-		filepath.Join(home, "Applications"),
-	}
-
-	apps, err := app.Discover(dirs...)
-	if err != nil {
-		return fmt.Errorf("failed to discover apps: %w", err)
+		return err
 	}
 
 	runner := &checker.RealCmdRunner{}

--- a/cmd/updater/scan.go
+++ b/cmd/updater/scan.go
@@ -7,6 +7,7 @@ import (
 	"text/tabwriter"
 
 	"github.com/luzhengda/updater/internal/app"
+	"github.com/luzhengda/updater/internal/checker"
 	"github.com/spf13/cobra"
 )
 
@@ -21,6 +22,8 @@ func init() {
 }
 
 func runScan(cmd *cobra.Command, args []string) error {
+	ctx := cmd.Context()
+
 	home, err := os.UserHomeDir()
 	if err != nil {
 		return fmt.Errorf("failed to get home directory: %w", err)
@@ -34,6 +37,14 @@ func runScan(cmd *cobra.Command, args []string) error {
 	apps, err := app.Discover(dirs...)
 	if err != nil {
 		return fmt.Errorf("failed to discover apps: %w", err)
+	}
+
+	runner := &checker.RealCmdRunner{}
+	formulaApps, fErr := discoverBrewFormulae(ctx, runner)
+	if fErr != nil {
+		fmt.Fprintf(os.Stderr, "warning: could not discover brew formulae: %v\n", fErr)
+	} else {
+		apps = append(apps, formulaApps...)
 	}
 
 	w := tabwriter.NewWriter(cmd.OutOrStdout(), 0, 4, 2, ' ', 0)

--- a/cmd/updater/ui.go
+++ b/cmd/updater/ui.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"os"
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/luzhengda/updater/internal/app"
@@ -46,6 +47,13 @@ func runUI(_ *cobra.Command, _ []string) error {
 		apps, err := discoverApps()
 		if err != nil {
 			return nil, err
+		}
+
+		formulaApps, fErr := discoverBrewFormulae(ctx, runner)
+		if fErr != nil {
+			fmt.Fprintf(os.Stderr, "warning: could not discover brew formulae: %v\n", fErr)
+		} else {
+			apps = append(apps, formulaApps...)
 		}
 
 		apps, err = enrichApps(ctx, apps, cfg, runner)

--- a/cmd/updater/update.go
+++ b/cmd/updater/update.go
@@ -225,6 +225,36 @@ func executeUpdate(ctx context.Context, r *checker.UpdateResult, runner checker.
 		}
 		return checker.ErrOpenedExternally
 
+	case "electron":
+		// Try direct install from ElectronUpdateURL if available.
+		if r.DownloadURL != "" && inst != nil && r.App.Path != "" {
+			wasRunning := quitAppIfRunning(ctx, r.App, runner)
+			err := inst.Install(ctx, r.DownloadURL, r.App.Path, r.App.Name)
+			if err == nil {
+				if wasRunning {
+					fmt.Printf("  Reopening %s...\n", r.App.Name)
+					_, _ = runner.Run(ctx, "open", "-a", r.App.Path)
+				}
+				return nil
+			}
+			fmt.Fprintf(os.Stderr, "  direct install failed, opening app for self-update: %v\n", err)
+		}
+		// Fallback: open app for self-update.
+		_, _ = runner.Run(ctx, "open", "-a", r.App.Path)
+		return checker.ErrOpenedExternally
+
+	case "setapp":
+		_, _ = runner.Run(ctx, "open", "-a", "/Applications/Setapp.app")
+		return checker.ErrOpenedExternally
+
+	case "toolbox":
+		_, _ = runner.Run(ctx, "open", "-a", "JetBrains Toolbox")
+		return checker.ErrOpenedExternally
+
+	case "adobe":
+		_, _ = runner.Run(ctx, "open", "-a", "/Applications/Adobe Creative Cloud/Adobe Creative Cloud.app")
+		return checker.ErrOpenedExternally
+
 	default:
 		return fmt.Errorf("unsupported update source: %s", r.Source)
 	}

--- a/cmd/updater/update.go
+++ b/cmd/updater/update.go
@@ -47,6 +47,14 @@ func runUpdate(cmd *cobra.Command, args []string) error {
 	}
 
 	runner := &checker.RealCmdRunner{}
+
+	formulaApps, fErr := discoverBrewFormulae(ctx, runner)
+	if fErr != nil {
+		fmt.Fprintf(os.Stderr, "warning: could not discover brew formulae: %v\n", fErr)
+	} else {
+		apps = append(apps, formulaApps...)
+	}
+
 	apps, err = enrichApps(ctx, apps, cfg, runner)
 	if err != nil {
 		return err
@@ -171,6 +179,17 @@ func executeUpdate(ctx context.Context, r *checker.UpdateResult, runner checker.
 		}
 		_, _ = runner.Run(ctx, "open", "macappstore://showUpdatesPage")
 		return checker.ErrOpenedExternally
+
+	case "formula":
+		if r.App.FormulaName == "" {
+			return fmt.Errorf("no formula name for %s", r.App.Name)
+		}
+		output, err := runner.Run(ctx, "brew", "upgrade", r.App.FormulaName)
+		if err != nil {
+			return fmt.Errorf("failed to upgrade formula %s: %w", r.App.FormulaName, err)
+		}
+		fmt.Println(string(output))
+		return nil
 
 	case "system":
 		_, err := runner.Run(ctx, "open", "x-apple.systempreferences:com.apple.Software-Update-Settings.extension")

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -6,26 +6,28 @@ import "strings"
 type Source string
 
 const (
-	SourceMAS     Source = "mas"
-	SourceSparkle Source = "sparkle"
-	SourceBrew    Source = "brew"
-	SourceGitHub  Source = "github"
-	SourceUnknown Source = "unknown"
+	SourceMAS         Source = "mas"
+	SourceSparkle     Source = "sparkle"
+	SourceBrew        Source = "brew"
+	SourceGitHub      Source = "github"
+	SourceBrewFormula Source = "formula"
+	SourceUnknown     Source = "unknown"
 )
 
 // App represents an installed macOS application.
 type App struct {
-	Name            string
-	BundleID        string
-	Version         string // CFBundleShortVersionString
-	Build           string // CFBundleVersion
-	Path            string
-	Source          Source
-	FeedURL         string // SUFeedURL
-	CaskName        string
-	MASID           string
-	GitHubRepo      string // "owner/repo"
-	InstalledViaBrew bool  // true only if actually installed via brew
+	Name             string
+	BundleID         string
+	Version          string // CFBundleShortVersionString
+	Build            string // CFBundleVersion
+	Path             string
+	Source           Source
+	FeedURL          string // SUFeedURL
+	CaskName         string
+	MASID            string
+	GitHubRepo       string // "owner/repo"
+	FormulaName      string // Homebrew formula name (e.g. "node", "python@3.12")
+	InstalledViaBrew bool   // true only if actually installed via brew
 }
 
 // ToCaskName converts an app display name to a likely Homebrew cask name.

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -11,6 +11,11 @@ const (
 	SourceBrew        Source = "brew"
 	SourceGitHub      Source = "github"
 	SourceBrewFormula Source = "formula"
+	SourceSystem      Source = "system"
+	SourceElectron    Source = "electron"
+	SourceSetapp      Source = "setapp"
+	SourceToolbox     Source = "toolbox"
+	SourceAdobe       Source = "adobe"
 	SourceUnknown     Source = "unknown"
 )
 
@@ -26,8 +31,9 @@ type App struct {
 	CaskName         string
 	MASID            string
 	GitHubRepo       string // "owner/repo"
-	FormulaName      string // Homebrew formula name (e.g. "node", "python@3.12")
-	InstalledViaBrew bool   // true only if actually installed via brew
+	FormulaName       string // Homebrew formula name (e.g. "node", "python@3.12")
+	InstalledViaBrew  bool   // true only if actually installed via brew
+	ElectronUpdateURL string // Generic update server base URL from app-update.yml
 }
 
 // ToCaskName converts an app display name to a likely Homebrew cask name.

--- a/internal/app/discovery.go
+++ b/internal/app/discovery.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"gopkg.in/yaml.v3"
 	"howett.net/plist"
 )
 
@@ -35,8 +36,20 @@ func Discover(dirs ...string) ([]*App, error) {
 		}
 
 		for _, entry := range entries {
-			if !entry.IsDir() || !strings.HasSuffix(entry.Name(), ".app") {
+			if !strings.HasSuffix(entry.Name(), ".app") {
 				continue
+			}
+			// Check if entry is a directory (or a symlink to a directory).
+			if !entry.IsDir() {
+				if entry.Type()&os.ModeSymlink == 0 {
+					continue
+				}
+				// Symlink: check if target is a directory.
+				target := filepath.Join(dir, entry.Name())
+				info, err := os.Stat(target) // follows symlinks
+				if err != nil || !info.IsDir() {
+					continue
+				}
 			}
 
 			appPath := filepath.Join(dir, entry.Name())
@@ -79,7 +92,11 @@ func parseApp(appPath string) (*App, error) {
 		Build:    info.BundleVersion,
 		Path:     appPath,
 		FeedURL:  info.FeedURL,
-		Source:   classifySource(contentsDir, info),
+		Source:   classifySource(appPath, contentsDir, info),
+	}
+
+	if a.Source == SourceElectron {
+		enrichElectronApp(contentsDir, a)
 	}
 
 	return a, nil
@@ -103,11 +120,21 @@ func readInfoPlist(path string) (*infoPlist, error) {
 }
 
 // classifySource determines the install source of an app.
-func classifySource(contentsDir string, info *infoPlist) Source {
+func classifySource(appPath, contentsDir string, info *infoPlist) Source {
 	// Check for Mac App Store receipt first.
 	receiptPath := filepath.Join(contentsDir, "_MASReceipt", "receipt")
 	if _, err := os.Stat(receiptPath); err == nil {
 		return SourceMAS
+	}
+
+	// Setapp: app is inside a Setapp directory.
+	if isSetappPath(appPath) {
+		return SourceSetapp
+	}
+
+	// JetBrains Toolbox: resolve symlinks, check if target is in Toolbox directory.
+	if isToolboxPath(appPath) {
+		return SourceToolbox
 	}
 
 	// Check for Sparkle framework + SUFeedURL.
@@ -116,5 +143,65 @@ func classifySource(contentsDir string, info *infoPlist) Source {
 		return SourceSparkle
 	}
 
+	// Electron: has Electron Framework but no Sparkle.
+	electronFramework := filepath.Join(contentsDir, "Frameworks", "Electron Framework.framework")
+	if _, err := os.Stat(electronFramework); err == nil {
+		return SourceElectron
+	}
+
+	// Adobe CC: non-MAS app with com.adobe.* bundle ID.
+	if strings.HasPrefix(info.BundleID, "com.adobe.") {
+		return SourceAdobe
+	}
+
 	return SourceUnknown
+}
+
+// isSetappPath checks if the app's parent directory is named "Setapp".
+func isSetappPath(appPath string) bool {
+	return filepath.Base(filepath.Dir(appPath)) == "Setapp"
+}
+
+// isToolboxPath resolves symlinks and checks if the target is in a JetBrains Toolbox directory.
+func isToolboxPath(appPath string) bool {
+	resolved, err := filepath.EvalSymlinks(appPath)
+	if err != nil {
+		return false
+	}
+	return strings.Contains(resolved, "JetBrains/Toolbox/apps")
+}
+
+// appUpdateYML maps the fields we read from app-update.yml.
+type appUpdateYML struct {
+	Provider string `yaml:"provider"`
+	Owner    string `yaml:"owner"`
+	Repo     string `yaml:"repo"`
+	URL      string `yaml:"url"`
+}
+
+// enrichElectronApp reads Contents/Resources/app-update.yml and enriches the app
+// with GitHub repo or generic update URL information.
+func enrichElectronApp(contentsDir string, a *App) {
+	ymlPath := filepath.Join(contentsDir, "Resources", "app-update.yml")
+	data, err := os.ReadFile(ymlPath)
+	if err != nil {
+		return // no app-update.yml, stays as SourceElectron
+	}
+
+	var cfg appUpdateYML
+	if err := yaml.Unmarshal(data, &cfg); err != nil {
+		return
+	}
+
+	switch cfg.Provider {
+	case "github":
+		if cfg.Owner != "" && cfg.Repo != "" {
+			a.GitHubRepo = cfg.Owner + "/" + cfg.Repo
+			a.Source = SourceGitHub
+		}
+	case "generic":
+		if cfg.URL != "" && (strings.HasPrefix(cfg.URL, "http://") || strings.HasPrefix(cfg.URL, "https://")) {
+			a.ElectronUpdateURL = cfg.URL
+		}
+	}
 }

--- a/internal/app/discovery_test.go
+++ b/internal/app/discovery_test.go
@@ -217,6 +217,252 @@ func TestDiscoverMultipleDirs(t *testing.T) {
 	}
 }
 
+func TestClassifySource_Electron(t *testing.T) {
+	dir := t.TempDir()
+
+	// Create an Electron app (has Electron Framework, no Sparkle, no MAS)
+	appPath := createFakeApp(t, dir, "Notion", plistData{
+		BundleName:         "Notion",
+		BundleID:           "notion.id",
+		ShortVersionString: "3.0.0",
+		BundleVersion:      "300",
+	}, false, false)
+
+	// Add Electron Framework
+	electronDir := filepath.Join(appPath, "Contents", "Frameworks", "Electron Framework.framework")
+	if err := os.MkdirAll(electronDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	apps, err := Discover(dir)
+	if err != nil {
+		t.Fatalf("Discover failed: %v", err)
+	}
+	if len(apps) != 1 {
+		t.Fatalf("expected 1 app, got %d", len(apps))
+	}
+	if apps[0].Source != SourceElectron {
+		t.Errorf("expected source %q, got %q", SourceElectron, apps[0].Source)
+	}
+}
+
+func TestClassifySource_Adobe(t *testing.T) {
+	dir := t.TempDir()
+
+	createFakeApp(t, dir, "Photoshop", plistData{
+		BundleName:         "Adobe Photoshop 2026",
+		BundleID:           "com.adobe.Photoshop",
+		ShortVersionString: "26.0",
+		BundleVersion:      "26.0.0",
+	}, false, false)
+
+	apps, err := Discover(dir)
+	if err != nil {
+		t.Fatalf("Discover failed: %v", err)
+	}
+	if len(apps) != 1 {
+		t.Fatalf("expected 1 app, got %d", len(apps))
+	}
+	if apps[0].Source != SourceAdobe {
+		t.Errorf("expected source %q, got %q", SourceAdobe, apps[0].Source)
+	}
+}
+
+func TestIsSetappPath(t *testing.T) {
+	tests := []struct {
+		path string
+		want bool
+	}{
+		{"/Applications/Setapp/Paste.app", true},
+		{"/Users/test/Applications/Setapp/CleanMyMac.app", true},
+		{"/Applications/Firefox.app", false},
+		{"/Applications/SetappHelper.app", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.path, func(t *testing.T) {
+			if got := isSetappPath(tt.path); got != tt.want {
+				t.Errorf("isSetappPath(%q) = %v, want %v", tt.path, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsToolboxPath(t *testing.T) {
+	// Create a fake Toolbox target directory
+	tmpDir := t.TempDir()
+	toolboxTarget := filepath.Join(tmpDir, "JetBrains", "Toolbox", "apps", "IDEA", "ch-0", "241.0", "IntelliJ IDEA.app")
+	if err := os.MkdirAll(toolboxTarget, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create a symlink pointing to the Toolbox target
+	symlinkPath := filepath.Join(tmpDir, "IntelliJ IDEA.app")
+	if err := os.Symlink(toolboxTarget, symlinkPath); err != nil {
+		t.Fatal(err)
+	}
+
+	if !isToolboxPath(symlinkPath) {
+		t.Error("expected isToolboxPath to be true for symlink to Toolbox dir")
+	}
+
+	// Non-Toolbox path should return false
+	regularPath := filepath.Join(tmpDir, "regular.app")
+	if err := os.MkdirAll(regularPath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if isToolboxPath(regularPath) {
+		t.Error("expected isToolboxPath to be false for regular path")
+	}
+}
+
+func TestEnrichElectronApp_GitHub(t *testing.T) {
+	dir := t.TempDir()
+
+	appPath := createFakeApp(t, dir, "MyElectron", plistData{
+		BundleName:         "MyElectron",
+		BundleID:           "com.example.electron",
+		ShortVersionString: "1.0.0",
+		BundleVersion:      "1",
+	}, false, false)
+
+	// Add Electron Framework
+	contentsDir := filepath.Join(appPath, "Contents")
+	electronDir := filepath.Join(contentsDir, "Frameworks", "Electron Framework.framework")
+	if err := os.MkdirAll(electronDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Write app-update.yml with GitHub provider
+	resourceDir := filepath.Join(contentsDir, "Resources")
+	if err := os.MkdirAll(resourceDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	yml := "provider: github\nowner: myorg\nrepo: myapp\n"
+	if err := os.WriteFile(filepath.Join(resourceDir, "app-update.yml"), []byte(yml), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	apps, err := Discover(dir)
+	if err != nil {
+		t.Fatalf("Discover failed: %v", err)
+	}
+	if len(apps) != 1 {
+		t.Fatalf("expected 1 app, got %d", len(apps))
+	}
+	a := apps[0]
+	if a.Source != SourceGitHub {
+		t.Errorf("expected source %q, got %q", SourceGitHub, a.Source)
+	}
+	if a.GitHubRepo != "myorg/myapp" {
+		t.Errorf("expected GitHubRepo %q, got %q", "myorg/myapp", a.GitHubRepo)
+	}
+}
+
+func TestEnrichElectronApp_Generic(t *testing.T) {
+	dir := t.TempDir()
+
+	appPath := createFakeApp(t, dir, "Notion", plistData{
+		BundleName:         "Notion",
+		BundleID:           "notion.id",
+		ShortVersionString: "3.0.0",
+		BundleVersion:      "300",
+	}, false, false)
+
+	// Add Electron Framework
+	contentsDir := filepath.Join(appPath, "Contents")
+	electronDir := filepath.Join(contentsDir, "Frameworks", "Electron Framework.framework")
+	if err := os.MkdirAll(electronDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Write app-update.yml with generic provider
+	resourceDir := filepath.Join(contentsDir, "Resources")
+	if err := os.MkdirAll(resourceDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	yml := "provider: generic\nurl: https://desktop-release.notion-static.com\n"
+	if err := os.WriteFile(filepath.Join(resourceDir, "app-update.yml"), []byte(yml), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	apps, err := Discover(dir)
+	if err != nil {
+		t.Fatalf("Discover failed: %v", err)
+	}
+	if len(apps) != 1 {
+		t.Fatalf("expected 1 app, got %d", len(apps))
+	}
+	a := apps[0]
+	if a.Source != SourceElectron {
+		t.Errorf("expected source %q, got %q", SourceElectron, a.Source)
+	}
+	if a.ElectronUpdateURL != "https://desktop-release.notion-static.com" {
+		t.Errorf("expected ElectronUpdateURL %q, got %q", "https://desktop-release.notion-static.com", a.ElectronUpdateURL)
+	}
+}
+
+func TestEnrichElectronApp_NoYML(t *testing.T) {
+	dir := t.TempDir()
+
+	appPath := createFakeApp(t, dir, "PlainElectron", plistData{
+		BundleName:         "PlainElectron",
+		BundleID:           "com.example.plain",
+		ShortVersionString: "1.0.0",
+		BundleVersion:      "1",
+	}, false, false)
+
+	// Add Electron Framework but no app-update.yml
+	electronDir := filepath.Join(appPath, "Contents", "Frameworks", "Electron Framework.framework")
+	if err := os.MkdirAll(electronDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	apps, err := Discover(dir)
+	if err != nil {
+		t.Fatalf("Discover failed: %v", err)
+	}
+	if len(apps) != 1 {
+		t.Fatalf("expected 1 app, got %d", len(apps))
+	}
+	a := apps[0]
+	if a.Source != SourceElectron {
+		t.Errorf("expected source %q, got %q", SourceElectron, a.Source)
+	}
+	if a.ElectronUpdateURL != "" {
+		t.Errorf("expected empty ElectronUpdateURL, got %q", a.ElectronUpdateURL)
+	}
+	if a.GitHubRepo != "" {
+		t.Errorf("expected empty GitHubRepo, got %q", a.GitHubRepo)
+	}
+}
+
+func TestClassifySource_SetappInDiscover(t *testing.T) {
+	// Create a Setapp-style directory structure
+	dir := t.TempDir()
+	setappDir := filepath.Join(dir, "Setapp")
+	if err := os.MkdirAll(setappDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	createFakeApp(t, setappDir, "Paste", plistData{
+		BundleName:         "Paste",
+		BundleID:           "com.widetechnologies.paste",
+		ShortVersionString: "3.0.0",
+		BundleVersion:      "300",
+	}, false, false)
+
+	apps, err := Discover(setappDir)
+	if err != nil {
+		t.Fatalf("Discover failed: %v", err)
+	}
+	if len(apps) != 1 {
+		t.Fatalf("expected 1 app, got %d", len(apps))
+	}
+	if apps[0].Source != SourceSetapp {
+		t.Errorf("expected source %q, got %q", SourceSetapp, apps[0].Source)
+	}
+}
+
 func TestToCaskName(t *testing.T) {
 	tests := []struct {
 		input string

--- a/internal/checker/brew.go
+++ b/internal/checker/brew.go
@@ -10,11 +10,17 @@ import (
 	"github.com/luzhengda/updater/internal/version"
 )
 
-// brewOutdatedItem represents a single entry from `brew outdated --cask --greedy --json`.
+// brewOutdatedItem represents a single entry from `brew outdated --json`.
 type brewOutdatedItem struct {
-	Name              string `json:"name"`
-	InstalledVersions string `json:"installed_versions"`
-	CurrentVersion    string `json:"current_version"`
+	Name              string          `json:"name"`
+	InstalledVersions json.RawMessage `json:"installed_versions"`
+	CurrentVersion    string          `json:"current_version"`
+}
+
+// brewOutdatedWrapper is the top-level object from `brew outdated --json` (Homebrew 4.x+).
+type brewOutdatedWrapper struct {
+	Formulae []brewOutdatedItem `json:"formulae"`
+	Casks    []brewOutdatedItem `json:"casks"`
 }
 
 // BrewChecker checks for Homebrew Cask updates.
@@ -80,13 +86,25 @@ func (b *BrewChecker) Check(ctx context.Context, a *app.App) (*UpdateResult, err
 	}, nil
 }
 
-// parseBrewOutdated parses the JSON output of `brew outdated --cask --greedy --json`.
+// parseBrewOutdated parses the JSON output of `brew outdated --json`.
+// Handles both the flat array format and the wrapped {"formulae":[],"casks":[]} format (Homebrew 4.x+).
 func parseBrewOutdated(data []byte) ([]brewOutdatedItem, error) {
+	// Try flat array first (legacy format / test mocks).
 	var items []brewOutdatedItem
-	if err := json.Unmarshal(data, &items); err != nil {
+	if err := json.Unmarshal(data, &items); err == nil {
+		return items, nil
+	}
+
+	// Try wrapped format (Homebrew 4.x+).
+	var wrapper brewOutdatedWrapper
+	if err := json.Unmarshal(data, &wrapper); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal brew outdated JSON: %w", err)
 	}
-	return items, nil
+	// Merge formulae and casks into a single list.
+	all := make([]brewOutdatedItem, 0, len(wrapper.Formulae)+len(wrapper.Casks))
+	all = append(all, wrapper.Formulae...)
+	all = append(all, wrapper.Casks...)
+	return all, nil
 }
 
 // ListInstalledCasks runs `brew list --cask` and returns a set of installed cask names.

--- a/internal/checker/brew_formula.go
+++ b/internal/checker/brew_formula.go
@@ -1,0 +1,112 @@
+package checker
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+
+	"github.com/luzhengda/updater/internal/app"
+	"github.com/luzhengda/updater/internal/version"
+)
+
+// BrewFormulaChecker checks for Homebrew formula updates.
+type BrewFormulaChecker struct {
+	runner   CmdRunner
+	once     sync.Once
+	outdated []brewOutdatedItem
+	parseErr error
+}
+
+// NewBrewFormulaChecker creates a new BrewFormulaChecker with the given command runner.
+// If runner is nil, a RealCmdRunner is used.
+func NewBrewFormulaChecker(runner CmdRunner) *BrewFormulaChecker {
+	if runner == nil {
+		runner = &RealCmdRunner{}
+	}
+	return &BrewFormulaChecker{runner: runner}
+}
+
+// Name returns the checker's display name.
+func (b *BrewFormulaChecker) Name() string {
+	return "formula"
+}
+
+// CanCheck returns true if the app is a brew formula.
+func (b *BrewFormulaChecker) CanCheck(a *app.App) bool {
+	return a.FormulaName != "" && a.Source == app.SourceBrewFormula
+}
+
+// loadOutdated fetches and caches the brew outdated formula list.
+// Safe for concurrent use — the command runs at most once.
+func (b *BrewFormulaChecker) loadOutdated(ctx context.Context) ([]brewOutdatedItem, error) {
+	b.once.Do(func() {
+		output, err := b.runner.Run(ctx, "brew", "outdated", "--formula", "--json")
+		if err != nil {
+			b.parseErr = fmt.Errorf("failed to run brew outdated --formula: %w", err)
+			return
+		}
+		b.outdated, b.parseErr = parseBrewOutdated(output)
+		if b.parseErr != nil {
+			b.parseErr = fmt.Errorf("failed to parse brew outdated output: %w", b.parseErr)
+		}
+	})
+	return b.outdated, b.parseErr
+}
+
+// Check looks up the app's formula in the cached outdated list.
+func (b *BrewFormulaChecker) Check(ctx context.Context, a *app.App) (*UpdateResult, error) {
+	if a.FormulaName == "" {
+		return nil, fmt.Errorf("failed to check formula update: no formula name for %s", a.Name)
+	}
+
+	items, err := b.loadOutdated(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, item := range items {
+		if item.Name == a.FormulaName {
+			latestVersion := item.CurrentVersion
+			return &UpdateResult{
+				App:            a,
+				Source:         "formula",
+				CurrentVersion: a.Version,
+				LatestVersion:  latestVersion,
+				HasUpdate:      version.IsNewer(a.Version, latestVersion),
+			}, nil
+		}
+	}
+
+	// Formula not in outdated list — no update available.
+	return &UpdateResult{
+		App:            a,
+		Source:         "formula",
+		CurrentVersion: a.Version,
+		LatestVersion:  a.Version,
+		HasUpdate:      false,
+	}, nil
+}
+
+// ListInstalledFormulae runs `brew list --formula --versions` and returns
+// a map of formula name to installed version.
+func ListInstalledFormulae(ctx context.Context, runner CmdRunner) (map[string]string, error) {
+	output, err := runner.Run(ctx, "brew", "list", "--formula", "--versions")
+	if err != nil {
+		return nil, fmt.Errorf("failed to run brew list --formula --versions: %w", err)
+	}
+
+	formulae := make(map[string]string)
+	for _, line := range strings.Split(strings.TrimSpace(string(output)), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		// Format: "name version [version...]" — take the last version (most recent).
+		parts := strings.Fields(line)
+		if len(parts) >= 2 {
+			formulae[parts[0]] = parts[len(parts)-1]
+		}
+	}
+	return formulae, nil
+}

--- a/internal/checker/brew_formula_test.go
+++ b/internal/checker/brew_formula_test.go
@@ -1,0 +1,219 @@
+package checker
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/luzhengda/updater/internal/app"
+)
+
+func TestBrewFormulaChecker_CanCheck(t *testing.T) {
+	c := NewBrewFormulaChecker(nil)
+
+	tests := []struct {
+		name string
+		app  *app.App
+		want bool
+	}{
+		{
+			name: "formula app",
+			app:  &app.App{Source: app.SourceBrewFormula, FormulaName: "node"},
+			want: true,
+		},
+		{
+			name: "formula source without formula name",
+			app:  &app.App{Source: app.SourceBrewFormula},
+			want: false,
+		},
+		{
+			name: "brew cask app",
+			app:  &app.App{Source: app.SourceBrew, CaskName: "firefox", InstalledViaBrew: true},
+			want: false,
+		},
+		{
+			name: "unknown source with formula name",
+			app:  &app.App{Source: app.SourceUnknown, FormulaName: "git"},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := c.CanCheck(tt.app)
+			if got != tt.want {
+				t.Errorf("CanCheck() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestBrewFormulaChecker_Check(t *testing.T) {
+	tests := []struct {
+		name          string
+		app           *app.App
+		output        []byte
+		err           error
+		wantUpdate    bool
+		wantLatest    string
+		wantErr       bool
+	}{
+		{
+			name: "outdated formula found",
+			app: &app.App{
+				Name:        "node",
+				Version:     "20.0.0",
+				Source:      app.SourceBrewFormula,
+				FormulaName: "node",
+			},
+			output:     []byte(`[{"name":"node","installed_versions":"20.0.0","current_version":"22.12.0"}]`),
+			wantUpdate: true,
+			wantLatest: "22.12.0",
+		},
+		{
+			name: "formula not in outdated list",
+			app: &app.App{
+				Name:        "git",
+				Version:     "2.47.1",
+				Source:      app.SourceBrewFormula,
+				FormulaName: "git",
+			},
+			output:     []byte(`[{"name":"node","installed_versions":"20.0.0","current_version":"22.12.0"}]`),
+			wantUpdate: false,
+			wantLatest: "2.47.1",
+		},
+		{
+			name: "empty JSON array",
+			app: &app.App{
+				Name:        "ffmpeg",
+				Version:     "7.0",
+				Source:      app.SourceBrewFormula,
+				FormulaName: "ffmpeg",
+			},
+			output:     []byte(`[]`),
+			wantUpdate: false,
+			wantLatest: "7.0",
+		},
+		{
+			name:    "missing formula name",
+			app:     &app.App{Name: "mystery", Source: app.SourceBrewFormula},
+			wantErr: true,
+		},
+		{
+			name: "brew command error",
+			app: &app.App{
+				Name:        "node",
+				Version:     "20.0.0",
+				Source:      app.SourceBrewFormula,
+				FormulaName: "node",
+			},
+			err:     fmt.Errorf("brew not found"),
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			runner := &MockCmdRunner{Output: tt.output, Err: tt.err}
+			c := NewBrewFormulaChecker(runner)
+
+			result, err := c.Check(context.Background(), tt.app)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if result.HasUpdate != tt.wantUpdate {
+				t.Errorf("HasUpdate = %v, want %v", result.HasUpdate, tt.wantUpdate)
+			}
+			if result.LatestVersion != tt.wantLatest {
+				t.Errorf("LatestVersion = %q, want %q", result.LatestVersion, tt.wantLatest)
+			}
+			if result.Source != "formula" {
+				t.Errorf("Source = %q, want %q", result.Source, "formula")
+			}
+		})
+	}
+}
+
+func TestListInstalledFormulae(t *testing.T) {
+	tests := []struct {
+		name    string
+		output  []byte
+		err     error
+		want    map[string]string
+		wantErr bool
+	}{
+		{
+			name:   "normal output",
+			output: []byte("node 22.12.0\ngit 2.47.1\nffmpeg 7.1\n"),
+			want: map[string]string{
+				"node":   "22.12.0",
+				"git":    "2.47.1",
+				"ffmpeg": "7.1",
+			},
+		},
+		{
+			name:   "versioned formula name",
+			output: []byte("python@3.12 3.12.8\nnode 22.12.0\n"),
+			want: map[string]string{
+				"python@3.12": "3.12.8",
+				"node":        "22.12.0",
+			},
+		},
+		{
+			name:   "multiple versions listed picks last",
+			output: []byte("node 20.0.0 22.12.0\n"),
+			want: map[string]string{
+				"node": "22.12.0",
+			},
+		},
+		{
+			name:   "malformed line with no version",
+			output: []byte("node\ngit 2.47.1\n"),
+			want: map[string]string{
+				"git": "2.47.1",
+			},
+		},
+		{
+			name:   "empty output",
+			output: []byte(""),
+			want:   map[string]string{},
+		},
+		{
+			name:    "brew error",
+			err:     fmt.Errorf("brew not found"),
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			runner := &MockCmdRunner{Output: tt.output, Err: tt.err}
+			got, err := ListInstalledFormulae(context.Background(), runner)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if len(got) != len(tt.want) {
+				t.Fatalf("got %d formulae, want %d", len(got), len(tt.want))
+			}
+			for name, wantVer := range tt.want {
+				if gotVer, ok := got[name]; !ok {
+					t.Errorf("missing formula %q", name)
+				} else if gotVer != wantVer {
+					t.Errorf("formula %q version = %q, want %q", name, gotVer, wantVer)
+				}
+			}
+		})
+	}
+}

--- a/internal/checker/brew_test.go
+++ b/internal/checker/brew_test.go
@@ -8,27 +8,53 @@ import (
 )
 
 func TestBrewChecker_ParseOutdated(t *testing.T) {
-	jsonData := []byte(`[{"name":"visual-studio-code","installed_versions":"1.90.0","current_version":"1.95.0"}]`)
+	t.Run("flat array format", func(t *testing.T) {
+		jsonData := []byte(`[{"name":"visual-studio-code","installed_versions":"1.90.0","current_version":"1.95.0"}]`)
 
-	items, err := parseBrewOutdated(jsonData)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+		items, err := parseBrewOutdated(jsonData)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(items) != 1 {
+			t.Fatalf("expected 1 item, got %d", len(items))
+		}
+		if items[0].Name != "visual-studio-code" {
+			t.Errorf("expected name visual-studio-code, got %s", items[0].Name)
+		}
+		if items[0].CurrentVersion != "1.95.0" {
+			t.Errorf("expected current version 1.95.0, got %s", items[0].CurrentVersion)
+		}
+	})
 
-	if len(items) != 1 {
-		t.Fatalf("expected 1 item, got %d", len(items))
-	}
+	t.Run("wrapped format with formulae and casks", func(t *testing.T) {
+		jsonData := []byte(`{"formulae":[{"name":"node","installed_versions":["20.0.0"],"current_version":"22.12.0"}],"casks":[{"name":"firefox","installed_versions":"1.0","current_version":"2.0"}]}`)
 
-	item := items[0]
-	if item.Name != "visual-studio-code" {
-		t.Errorf("expected name visual-studio-code, got %s", item.Name)
-	}
-	if item.InstalledVersions != "1.90.0" {
-		t.Errorf("expected installed version 1.90.0, got %s", item.InstalledVersions)
-	}
-	if item.CurrentVersion != "1.95.0" {
-		t.Errorf("expected current version 1.95.0, got %s", item.CurrentVersion)
-	}
+		items, err := parseBrewOutdated(jsonData)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(items) != 2 {
+			t.Fatalf("expected 2 items, got %d", len(items))
+		}
+		if items[0].Name != "node" {
+			t.Errorf("expected first item name node, got %s", items[0].Name)
+		}
+		if items[1].Name != "firefox" {
+			t.Errorf("expected second item name firefox, got %s", items[1].Name)
+		}
+	})
+
+	t.Run("wrapped format empty", func(t *testing.T) {
+		jsonData := []byte(`{"formulae":[],"casks":[]}`)
+
+		items, err := parseBrewOutdated(jsonData)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(items) != 0 {
+			t.Fatalf("expected 0 items, got %d", len(items))
+		}
+	})
 }
 
 func TestBrewChecker_CanCheck(t *testing.T) {

--- a/internal/checker/electron.go
+++ b/internal/checker/electron.go
@@ -1,0 +1,93 @@
+package checker
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/luzhengda/updater/internal/app"
+	"github.com/luzhengda/updater/internal/version"
+	"gopkg.in/yaml.v3"
+)
+
+// latestMacYML maps the fields from an Electron generic server's latest-mac.yml.
+type latestMacYML struct {
+	Version string `yaml:"version"`
+	Path    string `yaml:"path"`
+}
+
+// ElectronChecker checks for updates via Electron generic update servers.
+type ElectronChecker struct {
+	client *http.Client
+}
+
+// NewElectronChecker creates a new ElectronChecker.
+// If client is nil, http.DefaultClient is used.
+func NewElectronChecker(client *http.Client) *ElectronChecker {
+	if client == nil {
+		client = http.DefaultClient
+	}
+	return &ElectronChecker{client: client}
+}
+
+// Name returns the checker's display name.
+func (e *ElectronChecker) Name() string {
+	return "electron"
+}
+
+// CanCheck returns true if the app has an Electron update URL.
+func (e *ElectronChecker) CanCheck(a *app.App) bool {
+	return a.ElectronUpdateURL != "" && a.Source == app.SourceElectron
+}
+
+// Check fetches latest-mac.yml from the app's update server and compares versions.
+func (e *ElectronChecker) Check(ctx context.Context, a *app.App) (*UpdateResult, error) {
+	baseURL := strings.TrimRight(a.ElectronUpdateURL, "/")
+	url := baseURL + "/latest-mac.yml"
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request for %s: %w", a.Name, err)
+	}
+
+	resp, err := e.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch update info for %s: %w", a.Name, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("failed to fetch update info for %s: status %d", a.Name, resp.StatusCode)
+	}
+
+	const maxResponseSize = 1 << 20 // 1 MB
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseSize))
+	if err != nil {
+		return nil, fmt.Errorf("failed to read update info for %s: %w", a.Name, err)
+	}
+
+	var latest latestMacYML
+	if err := yaml.Unmarshal(body, &latest); err != nil {
+		return nil, fmt.Errorf("failed to parse update info for %s: %w", a.Name, err)
+	}
+
+	if latest.Version == "" {
+		return nil, fmt.Errorf("no version found in update info for %s", a.Name)
+	}
+
+	var downloadURL string
+	if latest.Path != "" {
+		downloadURL = baseURL + "/" + latest.Path
+	}
+
+	return &UpdateResult{
+		App:            a,
+		Source:         "electron",
+		CurrentVersion: a.Version,
+		LatestVersion:  latest.Version,
+		DownloadURL:    downloadURL,
+		HasUpdate:      version.IsNewer(a.Version, latest.Version),
+	}, nil
+}

--- a/internal/checker/electron_test.go
+++ b/internal/checker/electron_test.go
@@ -1,0 +1,186 @@
+package checker
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/luzhengda/updater/internal/app"
+)
+
+func TestElectronChecker_CanCheck(t *testing.T) {
+	c := NewElectronChecker(nil)
+
+	tests := []struct {
+		name string
+		app  *app.App
+		want bool
+	}{
+		{
+			name: "electron app with update URL",
+			app:  &app.App{Source: app.SourceElectron, ElectronUpdateURL: "https://update.example.com"},
+			want: true,
+		},
+		{
+			name: "electron app without update URL",
+			app:  &app.App{Source: app.SourceElectron},
+			want: false,
+		},
+		{
+			name: "non-electron source with update URL",
+			app:  &app.App{Source: app.SourceUnknown, ElectronUpdateURL: "https://update.example.com"},
+			want: false,
+		},
+		{
+			name: "github source",
+			app:  &app.App{Source: app.SourceGitHub},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := c.CanCheck(tt.app)
+			if got != tt.want {
+				t.Errorf("CanCheck() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestElectronChecker_Check(t *testing.T) {
+	tests := []struct {
+		name        string
+		appVersion  string
+		response    string
+		statusCode  int
+		wantUpdate  bool
+		wantVersion string
+		wantErr     bool
+	}{
+		{
+			name:       "update available",
+			appVersion: "1.0.0",
+			response: `version: 2.0.0
+files:
+  - url: TestApp-2.0.0-mac.zip
+    sha512: abc123
+path: TestApp-2.0.0-mac.zip
+sha512: abc123
+releaseDate: '2026-02-14T10:00:00.000Z'
+`,
+			statusCode:  200,
+			wantUpdate:  true,
+			wantVersion: "2.0.0",
+		},
+		{
+			name:       "up to date",
+			appVersion: "2.0.0",
+			response: `version: 2.0.0
+path: TestApp-2.0.0-mac.zip
+`,
+			statusCode:  200,
+			wantUpdate:  false,
+			wantVersion: "2.0.0",
+		},
+		{
+			name:        "server error",
+			appVersion:  "1.0.0",
+			response:    "Internal Server Error",
+			statusCode:  500,
+			wantErr:     true,
+			wantVersion: "",
+		},
+		{
+			name:        "malformed YAML",
+			appVersion:  "1.0.0",
+			response:    "{{not yaml at all",
+			statusCode:  200,
+			wantErr:     true,
+			wantVersion: "",
+		},
+		{
+			name:        "empty version",
+			appVersion:  "1.0.0",
+			response:    "path: TestApp.zip\n",
+			statusCode:  200,
+			wantErr:     true,
+			wantVersion: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path != "/latest-mac.yml" {
+					t.Errorf("unexpected path: %s", r.URL.Path)
+					http.NotFound(w, r)
+					return
+				}
+				w.WriteHeader(tt.statusCode)
+				w.Write([]byte(tt.response))
+			}))
+			defer ts.Close()
+
+			c := NewElectronChecker(ts.Client())
+			a := &app.App{
+				Name:              "TestApp",
+				Version:           tt.appVersion,
+				Source:            app.SourceElectron,
+				ElectronUpdateURL: ts.URL,
+			}
+
+			result, err := c.Check(context.Background(), a)
+			if tt.wantErr {
+				if err == nil {
+					t.Error("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if result.HasUpdate != tt.wantUpdate {
+				t.Errorf("HasUpdate = %v, want %v", result.HasUpdate, tt.wantUpdate)
+			}
+			if result.LatestVersion != tt.wantVersion {
+				t.Errorf("LatestVersion = %q, want %q", result.LatestVersion, tt.wantVersion)
+			}
+			if result.Source != "electron" {
+				t.Errorf("Source = %q, want %q", result.Source, "electron")
+			}
+		})
+	}
+}
+
+func TestElectronChecker_DownloadURL(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("version: 2.0.0\npath: TestApp-2.0.0-mac.zip\n"))
+	}))
+	defer ts.Close()
+
+	c := NewElectronChecker(ts.Client())
+	a := &app.App{
+		Name:              "TestApp",
+		Version:           "1.0.0",
+		Source:            app.SourceElectron,
+		ElectronUpdateURL: ts.URL,
+	}
+
+	result, err := c.Check(context.Background(), a)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := ts.URL + "/TestApp-2.0.0-mac.zip"
+	if result.DownloadURL != want {
+		t.Errorf("DownloadURL = %q, want %q", result.DownloadURL, want)
+	}
+}
+
+func TestElectronChecker_Name(t *testing.T) {
+	c := NewElectronChecker(nil)
+	if c.Name() != "electron" {
+		t.Errorf("Name() = %q, want %q", c.Name(), "electron")
+	}
+}

--- a/internal/checker/managed.go
+++ b/internal/checker/managed.go
@@ -1,0 +1,42 @@
+package checker
+
+import (
+	"context"
+
+	"github.com/luzhengda/updater/internal/app"
+)
+
+// ManagedChecker handles apps managed by external platforms (Setapp, JetBrains Toolbox, Adobe CC).
+// These platforms manage their own updates, so this checker simply acknowledges the app.
+type ManagedChecker struct{}
+
+// NewManagedChecker creates a new ManagedChecker.
+func NewManagedChecker() *ManagedChecker {
+	return &ManagedChecker{}
+}
+
+// Name returns the checker's display name.
+func (m *ManagedChecker) Name() string {
+	return "managed"
+}
+
+// CanCheck returns true if the app is managed by Setapp, JetBrains Toolbox, or Adobe CC.
+func (m *ManagedChecker) CanCheck(a *app.App) bool {
+	switch a.Source {
+	case app.SourceSetapp, app.SourceToolbox, app.SourceAdobe:
+		return true
+	default:
+		return false
+	}
+}
+
+// Check returns a no-update result. Managed platforms handle their own updates.
+func (m *ManagedChecker) Check(_ context.Context, a *app.App) (*UpdateResult, error) {
+	return &UpdateResult{
+		App:            a,
+		Source:         string(a.Source),
+		CurrentVersion: a.Version,
+		LatestVersion:  a.Version,
+		HasUpdate:      false,
+	}, nil
+}

--- a/internal/checker/managed_test.go
+++ b/internal/checker/managed_test.go
@@ -1,0 +1,112 @@
+package checker
+
+import (
+	"context"
+	"testing"
+
+	"github.com/luzhengda/updater/internal/app"
+)
+
+func TestManagedChecker_CanCheck(t *testing.T) {
+	c := NewManagedChecker()
+
+	tests := []struct {
+		name string
+		app  *app.App
+		want bool
+	}{
+		{
+			name: "setapp app",
+			app:  &app.App{Source: app.SourceSetapp},
+			want: true,
+		},
+		{
+			name: "toolbox app",
+			app:  &app.App{Source: app.SourceToolbox},
+			want: true,
+		},
+		{
+			name: "adobe app",
+			app:  &app.App{Source: app.SourceAdobe},
+			want: true,
+		},
+		{
+			name: "unknown app",
+			app:  &app.App{Source: app.SourceUnknown},
+			want: false,
+		},
+		{
+			name: "sparkle app",
+			app:  &app.App{Source: app.SourceSparkle},
+			want: false,
+		},
+		{
+			name: "electron app",
+			app:  &app.App{Source: app.SourceElectron},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := c.CanCheck(tt.app)
+			if got != tt.want {
+				t.Errorf("CanCheck() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestManagedChecker_Check(t *testing.T) {
+	c := NewManagedChecker()
+
+	tests := []struct {
+		name       string
+		app        *app.App
+		wantSource string
+	}{
+		{
+			name:       "setapp returns no update",
+			app:        &app.App{Name: "Paste", Version: "3.0.0", Source: app.SourceSetapp},
+			wantSource: "setapp",
+		},
+		{
+			name:       "toolbox returns no update",
+			app:        &app.App{Name: "IntelliJ IDEA", Version: "2026.1", Source: app.SourceToolbox},
+			wantSource: "toolbox",
+		},
+		{
+			name:       "adobe returns no update",
+			app:        &app.App{Name: "Adobe Photoshop", Version: "26.0", BundleID: "com.adobe.Photoshop", Source: app.SourceAdobe},
+			wantSource: "adobe",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := c.Check(context.Background(), tt.app)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if result.HasUpdate {
+				t.Error("expected HasUpdate to be false")
+			}
+			if result.Source != tt.wantSource {
+				t.Errorf("Source = %q, want %q", result.Source, tt.wantSource)
+			}
+			if result.CurrentVersion != tt.app.Version {
+				t.Errorf("CurrentVersion = %q, want %q", result.CurrentVersion, tt.app.Version)
+			}
+			if result.LatestVersion != tt.app.Version {
+				t.Errorf("LatestVersion = %q, want %q", result.LatestVersion, tt.app.Version)
+			}
+		})
+	}
+}
+
+func TestManagedChecker_Name(t *testing.T) {
+	c := NewManagedChecker()
+	if c.Name() != "managed" {
+		t.Errorf("Name() = %q, want %q", c.Name(), "managed")
+	}
+}

--- a/internal/tui/styles.go
+++ b/internal/tui/styles.go
@@ -86,6 +86,8 @@ func styledSource(source string) string {
 		return sourceStyleSparkle.Render("sparkle")
 	case "brew":
 		return sourceStyleBrew.Render("homebrew")
+	case "formula":
+		return sourceStyleBrew.Render("formula")
 	case "brew-info":
 		return sourceStyleBrewInfo.Render("homebrew")
 	case "github":
@@ -111,6 +113,8 @@ func sourceDisplayName(source string) string {
 		return "app store"
 	case "brew", "brew-info":
 		return "homebrew"
+	case "formula":
+		return "formula"
 	default:
 		return source
 	}

--- a/internal/tui/styles.go
+++ b/internal/tui/styles.go
@@ -94,6 +94,14 @@ func styledSource(source string) string {
 		return sourceStyleGitHub.Render("github")
 	case "system":
 		return sourceStyleSystem.Render("system")
+	case "electron":
+		return sourceStyleBrewInfo.Render("electron")
+	case "setapp":
+		return sourceStyleSparkle.Render("setapp")
+	case "toolbox":
+		return sourceStyleGitHub.Render("toolbox")
+	case "adobe":
+		return styleError.Render("adobe")
 	case "unknown":
 		return sourceStyleUnknown.Render("unknown")
 	default:
@@ -115,6 +123,8 @@ func sourceDisplayName(source string) string {
 		return "homebrew"
 	case "formula":
 		return "formula"
+	case "electron", "setapp", "toolbox", "adobe":
+		return source
 	default:
 		return source
 	}


### PR DESCRIPTION
## Summary
- Detect **Electron** apps via `Electron Framework.framework`, auto-discover GitHub repos and generic update URLs from `app-update.yml` (tested with Notion's live update server)
- Detect **Setapp**, **JetBrains Toolbox** (symlink resolution), and **Adobe CC** (`com.adobe.*` bundle ID) as managed platforms
- New `ElectronChecker` fetches `latest-mac.yml` from generic update servers; `ManagedChecker` labels managed platforms
- Fix: symlinked `.app` bundles (e.g. Toolbox-managed IDEs) are now discovered; `scan` command uses shared `discoverApps()`; re-enable hidden shell completion command; add `SourceSystem` constant

## Test plan
- [x] `go vet ./...` clean
- [x] `go test -race ./...` — all 8 packages pass (21 new tests)
- [x] `updater scan` — Notion=electron, 1Password/Claude/GitHub Desktop/VS Code=electron, Adobe Lightroom=mas (MAS priority over adobe)
- [x] `updater check` — Notion checked via Electron generic server (7.4.0 ok)
- [x] Fake Setapp bundle → detected as `setapp`
- [x] Fake Toolbox symlink → detected as `toolbox`
- [x] Fake Adobe bundle (non-MAS) → detected as `adobe`
- [x] JetBrains Toolbox installed/uninstalled via brew for real symlink test
- [x] `updater completion zsh` works (hidden from help)