### PR TITLE
chore: migrate to goreleaser with homebrew_casks

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,85 +15,29 @@ jobs:
   release:
     runs-on: macos-latest
     timeout-minutes: 15
-    env:
-      TAG: ${{ github.ref_name }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.25.x"
+          go-version-file: go.mod
 
       - name: Test
         run: go test -race ./...
 
-      - name: Build arm64
-        run: GOARCH=arm64 go build -ldflags "-s -w -X main.version=$TAG" -o updater-darwin-arm64 ./cmd/updater
-
-      - name: Build amd64
-        run: GOARCH=amd64 go build -ldflags "-s -w -X main.version=$TAG" -o updater-darwin-amd64 ./cmd/updater
-
-      - name: Create GitHub release
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh release create "$TAG" updater-darwin-arm64 updater-darwin-amd64 --generate-notes
-
-      - name: Update Homebrew tap
-        env:
-          GH_TOKEN: ${{ secrets.TAP_GITHUB_TOKEN }}
+      - name: Generate completions
         run: |
-          set -euo pipefail
+          mkdir -p completions
+          go run ./cmd/updater completion bash > completions/updater.bash
+          go run ./cmd/updater completion zsh > completions/updater.zsh
+          go run ./cmd/updater completion fish > completions/updater.fish
 
-          # Download source tarball and compute SHA256
-          curl -sfL "https://github.com/lu-zhengda/updater/archive/refs/tags/${TAG}.tar.gz" -o source.tar.gz
-          SHA256=$(shasum -a 256 source.tar.gz | awk '{print $1}')
-          echo "SHA256: $SHA256"
-
-          # Build updated formula
-          cat > updater.rb <<FORMULA
-          class Updater < Formula
-            desc "macOS app update manager"
-            homepage "https://github.com/lu-zhengda/updater"
-            url "https://github.com/lu-zhengda/updater/archive/refs/tags/${TAG}.tar.gz"
-            sha256 "${SHA256}"
-            license "MIT"
-
-            depends_on "go" => :build
-            depends_on :macos
-
-            def install
-              ldflags = "-s -w -X main.version=#{version}"
-              system "go", "build", *std_go_args(ldflags:), "./cmd/updater"
-
-              generate_completions_from_executable(bin/"updater", "completion")
-            end
-
-            test do
-              assert_match version.to_s, shell_output("#{bin}/updater --version")
-            end
-          end
-          FORMULA
-
-          # Remove leading whitespace from heredoc
-          sed -i '' 's/^          //' updater.rb
-
-          # Get current file SHA (needed for update via Contents API)
-          FILE_SHA=$(gh api repos/lu-zhengda/homebrew-tap/contents/Formula/updater.rb --jq '.sha' 2>/dev/null || echo "")
-
-          # Base64 encode the formula
-          CONTENT=$(base64 < updater.rb | tr -d '\n')
-
-          if [ -n "$FILE_SHA" ]; then
-            # Update existing file
-            gh api repos/lu-zhengda/homebrew-tap/contents/Formula/updater.rb \
-              -X PUT \
-              -f message="updater ${TAG}" \
-              -f content="$CONTENT" \
-              -f sha="$FILE_SHA"
-          else
-            # Create new file
-            gh api repos/lu-zhengda/homebrew-tap/contents/Formula/updater.rb \
-              -X PUT \
-              -f message="updater ${TAG}" \
-              -f content="$CONTENT"
-          fi
+      - uses: goreleaser/goreleaser-action@v6
+        with:
+          version: "~> v2"
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,13 @@
 # Binary
 /updater
 
+# GoReleaser
+dist/
+completions/
+
+# Worktrees
+.worktrees/
+
 # IDE
 .idea/
 .vscode/

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,53 @@
+version: 2
+
+builds:
+  - main: ./cmd/updater
+    binary: updater
+    goos:
+      - darwin
+    goarch:
+      - amd64
+      - arm64
+    ldflags:
+      - -s -w
+      - -X main.version={{.Version}}
+
+archives:
+  - formats:
+      - tar.gz
+    name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+    files:
+      - completions/*
+
+checksum:
+  name_template: "checksums.txt"
+
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - "^docs:"
+      - "^test:"
+      - "^chore:"
+
+homebrew_casks:
+  - repository:
+      owner: lu-zhengda
+      name: homebrew-tap
+      token: "{{ .Env.HOMEBREW_TAP_TOKEN }}"
+    directory: Casks
+    homepage: "https://github.com/lu-zhengda/updater"
+    description: "macOS app update manager"
+    license: "MIT"
+    binaries:
+      - updater
+    completions:
+      bash: completions/updater.bash
+      zsh: completions/updater.zsh
+      fish: completions/updater.fish
+    hooks:
+      post:
+        install: |
+          if OS.mac?
+            system_command "/usr/bin/xattr", args: ["-dr", "com.apple.quarantine", "#{staged_path}/updater"]
+          end


### PR DESCRIPTION
## Summary
- Add `.goreleaser.yaml` with `homebrew_casks` configuration
- Replace custom release workflow (manual builds + Contents API formula push) with goreleaser-action
- Distribute pre-compiled binaries via Homebrew cask instead of source-build formula
- Generate shell completions in CI and include in cask
- Add `.worktrees/`, `dist/`, `completions/` to `.gitignore`

## Breaking changes
- Homebrew install switches from source-build formula to pre-compiled cask
- Users no longer need Go installed to install updater
- Secret changes: uses `HOMEBREW_TAP_TOKEN` (same as other repos)

## Test plan
- [ ] CI passes
- [ ] Release creates GitHub release with darwin/amd64+arm64 archives
- [ ] Cask pushed to homebrew-tap `Casks/` directory