### PR TITLE
feat: v0.6.0 — release pipeline, policies, doctor, rollback, TUI history

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Binary
 /updater
+/updater-menubar
 
 # GoReleaser
 dist/

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,7 +1,8 @@
 version: 2
 
 builds:
-  - main: ./cmd/updater
+  - id: updater
+    main: ./cmd/updater
     binary: updater
     goos:
       - darwin
@@ -11,11 +12,27 @@ builds:
     ldflags:
       - -s -w
       - -X main.version={{.Version}}
+  - id: updater-menubar
+    main: ./cmd/updater-menubar
+    binary: updater-menubar
+    goos:
+      - darwin
+    goarch:
+      - amd64
+      - arm64
+    ldflags:
+      - -s -w
+
+universal_binaries:
+  - id: updater
+    replace: true
+  - id: updater-menubar
+    replace: true
 
 archives:
   - formats:
       - tar.gz
-    name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+    name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}"
     files:
       - completions/*
 
@@ -41,6 +58,7 @@ homebrew_casks:
     license: "MIT"
     binaries:
       - updater
+      - updater-menubar
     completions:
       bash: completions/updater.bash
       zsh: completions/updater.zsh
@@ -50,4 +68,5 @@ homebrew_casks:
         install: |
           if OS.mac?
             system_command "/usr/bin/xattr", args: ["-dr", "com.apple.quarantine", "#{staged_path}/updater"]
+            system_command "/usr/bin/xattr", args: ["-dr", "com.apple.quarantine", "#{staged_path}/updater-menubar"]
           end

--- a/cmd/updater/doctor.go
+++ b/cmd/updater/doctor.go
@@ -1,0 +1,237 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/luzhengda/updater/internal/backup"
+	"github.com/luzhengda/updater/internal/checker"
+	"github.com/luzhengda/updater/internal/config"
+	"github.com/luzhengda/updater/internal/history"
+	"github.com/spf13/cobra"
+)
+
+var flagDoctorJSON bool
+
+var doctorCmd = &cobra.Command{
+	Use:   "doctor",
+	Short: "Check system health and dependencies",
+	RunE:  runDoctor,
+}
+
+func init() {
+	doctorCmd.Flags().BoolVar(&flagDoctorJSON, "json", false, "output as JSON")
+	rootCmd.AddCommand(doctorCmd)
+}
+
+type doctorCheck struct {
+	Name    string `json:"name"`
+	Status  string `json:"status"` // "ok", "warning", "not_installed"
+	Detail  string `json:"detail"`
+}
+
+func runDoctor(cmd *cobra.Command, _ []string) error {
+	ctx := cmd.Context()
+	runner := &checker.RealCmdRunner{}
+	var checks []doctorCheck
+
+	// External tools.
+	tools := []string{"brew", "mas", "osascript", "hdiutil", "ditto", "sw_vers"}
+	for _, tool := range tools {
+		checks = append(checks, checkTool(ctx, runner, tool))
+	}
+
+	// Config file.
+	checks = append(checks, checkConfig())
+
+	// Backup directory.
+	checks = append(checks, checkBackups())
+
+	// History file.
+	checks = append(checks, checkHistory())
+
+	// Schedule agent.
+	checks = append(checks, checkScheduleAgent())
+
+	// Menubar agent.
+	checks = append(checks, checkMenubarAgent())
+
+	// GitHub token.
+	cfg, _ := config.Load(config.DefaultPath())
+	if cfg != nil {
+		checks = append(checks, checkGitHubToken(ctx, cfg))
+	}
+
+	// Network.
+	checks = append(checks, checkNetwork())
+
+	if flagDoctorJSON {
+		enc := json.NewEncoder(cmd.OutOrStdout())
+		enc.SetIndent("", "  ")
+		return enc.Encode(checks)
+	}
+
+	for _, c := range checks {
+		var prefix string
+		switch c.Status {
+		case "ok":
+			prefix = "[ok]"
+		case "warning":
+			prefix = "[!!]"
+		case "not_installed":
+			prefix = "[--]"
+		default:
+			prefix = "[??]"
+		}
+		fmt.Fprintf(cmd.OutOrStdout(), "%s %s (%s)\n", prefix, c.Name, c.Detail)
+	}
+	return nil
+}
+
+func checkTool(ctx context.Context, runner checker.CmdRunner, tool string) doctorCheck {
+	output, err := runner.Run(ctx, "which", tool)
+	if err != nil {
+		return doctorCheck{Name: tool, Status: "warning", Detail: "not found"}
+	}
+	path := string(output)
+	if len(path) > 0 && path[len(path)-1] == '\n' {
+		path = path[:len(path)-1]
+	}
+	return doctorCheck{Name: tool, Status: "ok", Detail: path}
+}
+
+func checkConfig() doctorCheck {
+	cfgPath := config.DefaultPath()
+	_, err := config.Load(cfgPath)
+	if err != nil {
+		return doctorCheck{Name: "Config", Status: "warning", Detail: fmt.Sprintf("error: %v", err)}
+	}
+	if _, statErr := os.Stat(cfgPath); os.IsNotExist(statErr) {
+		return doctorCheck{Name: "Config", Status: "ok", Detail: "using defaults"}
+	}
+	return doctorCheck{Name: "Config", Status: "ok", Detail: cfgPath}
+}
+
+func checkBackups() doctorCheck {
+	baseDir := backup.DefaultBaseDir()
+	info, err := os.Stat(baseDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return doctorCheck{Name: "Backups", Status: "ok", Detail: "no backups yet"}
+		}
+		return doctorCheck{Name: "Backups", Status: "warning", Detail: fmt.Sprintf("error: %v", err)}
+	}
+	if !info.IsDir() {
+		return doctorCheck{Name: "Backups", Status: "warning", Detail: "path is not a directory"}
+	}
+
+	// Count backup subdirectories.
+	entries, err := os.ReadDir(baseDir)
+	if err != nil {
+		return doctorCheck{Name: "Backups", Status: "warning", Detail: fmt.Sprintf("unreadable: %v", err)}
+	}
+	count := 0
+	for _, e := range entries {
+		if e.IsDir() {
+			count++
+		}
+	}
+
+	// Check writable by creating a temp file.
+	tmpFile := filepath.Join(baseDir, ".doctor-write-test")
+	if err := os.WriteFile(tmpFile, []byte("test"), 0o644); err != nil {
+		return doctorCheck{Name: "Backups", Status: "warning", Detail: fmt.Sprintf("%d apps, not writable", count)}
+	}
+	os.Remove(tmpFile)
+
+	return doctorCheck{Name: "Backups", Status: "ok", Detail: fmt.Sprintf("%d apps", count)}
+}
+
+func checkHistory() doctorCheck {
+	histPath := history.DefaultPath()
+	entries, err := history.List(histPath)
+	if err != nil {
+		return doctorCheck{Name: "History", Status: "warning", Detail: fmt.Sprintf("error: %v", err)}
+	}
+	if entries == nil {
+		return doctorCheck{Name: "History", Status: "ok", Detail: "no history file yet"}
+	}
+	return doctorCheck{Name: "History", Status: "ok", Detail: fmt.Sprintf("%d entries", len(entries))}
+}
+
+func checkScheduleAgent() doctorCheck {
+	p, err := schedulePlistPath()
+	if err != nil {
+		return doctorCheck{Name: "Schedule agent", Status: "warning", Detail: err.Error()}
+	}
+	if _, err := os.Stat(p); os.IsNotExist(err) {
+		return doctorCheck{Name: "Schedule agent", Status: "not_installed", Detail: "not installed"}
+	}
+	if scheduleExists() {
+		return doctorCheck{Name: "Schedule agent", Status: "ok", Detail: "installed"}
+	}
+	return doctorCheck{Name: "Schedule agent", Status: "warning", Detail: "plist exists but not loaded"}
+}
+
+func checkMenubarAgent() doctorCheck {
+	p, err := menubarPlistPath()
+	if err != nil {
+		return doctorCheck{Name: "Menubar agent", Status: "warning", Detail: err.Error()}
+	}
+	if _, err := os.Stat(p); os.IsNotExist(err) {
+		return doctorCheck{Name: "Menubar agent", Status: "not_installed", Detail: "not installed"}
+	}
+	return doctorCheck{Name: "Menubar agent", Status: "ok", Detail: "installed"}
+}
+
+func checkGitHubToken(ctx context.Context, cfg *config.Config) doctorCheck {
+	token := cfg.ResolveGitHubToken()
+	if token == "" {
+		return doctorCheck{Name: "GitHub token", Status: "not_installed", Detail: "not configured"}
+	}
+
+	client := &http.Client{Timeout: 5 * time.Second}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "https://api.github.com/rate_limit", nil)
+	if err != nil {
+		return doctorCheck{Name: "GitHub token", Status: "warning", Detail: "failed to create request"}
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return doctorCheck{Name: "GitHub token", Status: "warning", Detail: "request failed"}
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return doctorCheck{Name: "GitHub token", Status: "warning", Detail: "invalid token"}
+	}
+
+	var rateResp struct {
+		Rate struct {
+			Remaining int `json:"remaining"`
+			Limit     int `json:"limit"`
+		} `json:"rate"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&rateResp); err != nil {
+		return doctorCheck{Name: "GitHub token", Status: "ok", Detail: "valid (could not read rate)"}
+	}
+
+	return doctorCheck{Name: "GitHub token", Status: "ok",
+		Detail: fmt.Sprintf("%d/%d remaining", rateResp.Rate.Remaining, rateResp.Rate.Limit)}
+}
+
+func checkNetwork() doctorCheck {
+	client := &http.Client{Timeout: 5 * time.Second}
+	resp, err := client.Get("https://api.github.com")
+	if err != nil {
+		return doctorCheck{Name: "Network", Status: "warning", Detail: "unreachable"}
+	}
+	resp.Body.Close()
+	return doctorCheck{Name: "Network", Status: "ok", Detail: "reachable"}
+}

--- a/cmd/updater/doctor_test.go
+++ b/cmd/updater/doctor_test.go
@@ -1,0 +1,122 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/luzhengda/updater/internal/checker"
+	"github.com/luzhengda/updater/internal/history"
+)
+
+func TestCheckTool_Present(t *testing.T) {
+	runner := &checker.MockCmdRunner{Output: []byte("/usr/bin/brew\n")}
+	c := checkTool(context.Background(), runner, "brew")
+	if c.Status != "ok" {
+		t.Errorf("Status = %q, want %q", c.Status, "ok")
+	}
+	if c.Detail != "/usr/bin/brew" {
+		t.Errorf("Detail = %q, want %q", c.Detail, "/usr/bin/brew")
+	}
+}
+
+func TestCheckTool_Missing(t *testing.T) {
+	runner := &checker.MockCmdRunner{Err: os.ErrNotExist}
+	c := checkTool(context.Background(), runner, "mas")
+	if c.Status != "warning" {
+		t.Errorf("Status = %q, want %q", c.Status, "warning")
+	}
+	if c.Detail != "not found" {
+		t.Errorf("Detail = %q, want %q", c.Detail, "not found")
+	}
+}
+
+func TestCheckHistory_Valid(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "history.json")
+
+	entries := []history.Entry{
+		{AppName: "Firefox", Success: true},
+		{AppName: "Chrome", Success: true},
+	}
+	data, _ := json.Marshal(entries)
+	os.WriteFile(path, data, 0o644)
+
+	orig := history.DefaultPath
+	history.DefaultPath = func() string { return path }
+	defer func() { history.DefaultPath = orig }()
+
+	c := checkHistory()
+	if c.Status != "ok" {
+		t.Errorf("Status = %q, want %q", c.Status, "ok")
+	}
+	if !strings.Contains(c.Detail, "2 entries") {
+		t.Errorf("Detail = %q, want to contain '2 entries'", c.Detail)
+	}
+}
+
+func TestCheckHistory_Invalid(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "history.json")
+	os.WriteFile(path, []byte("{bad json"), 0o644)
+
+	orig := history.DefaultPath
+	history.DefaultPath = func() string { return path }
+	defer func() { history.DefaultPath = orig }()
+
+	c := checkHistory()
+	if c.Status != "warning" {
+		t.Errorf("Status = %q, want %q", c.Status, "warning")
+	}
+}
+
+func TestDoctor_JSONOutput(t *testing.T) {
+	// Test that the JSON output format is valid by running checkTool directly.
+	runner := &checker.MockCmdRunner{Output: []byte("/usr/bin/brew\n")}
+	checks := []doctorCheck{
+		checkTool(context.Background(), runner, "brew"),
+	}
+
+	var buf bytes.Buffer
+	enc := json.NewEncoder(&buf)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(checks); err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+
+	var got []doctorCheck
+	if err := json.Unmarshal(buf.Bytes(), &got); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+	if len(got) != 1 {
+		t.Errorf("expected 1 check, got %d", len(got))
+	}
+	if got[0].Name != "brew" {
+		t.Errorf("Name = %q, want %q", got[0].Name, "brew")
+	}
+}
+
+func TestDoctor_AllToolsPresent(t *testing.T) {
+	runner := &checker.MultiMockCmdRunner{
+		Responses: map[string]checker.MockResponse{
+			"which brew":      {Output: []byte("/opt/homebrew/bin/brew\n")},
+			"which mas":       {Output: []byte("/usr/local/bin/mas\n")},
+			"which osascript": {Output: []byte("/usr/bin/osascript\n")},
+			"which hdiutil":   {Output: []byte("/usr/bin/hdiutil\n")},
+			"which ditto":     {Output: []byte("/usr/bin/ditto\n")},
+			"which sw_vers":   {Output: []byte("/usr/bin/sw_vers\n")},
+		},
+	}
+
+	tools := []string{"brew", "mas", "osascript", "hdiutil", "ditto", "sw_vers"}
+	for _, tool := range tools {
+		c := checkTool(context.Background(), runner, tool)
+		if c.Status != "ok" {
+			t.Errorf("checkTool(%q) Status = %q, want %q", tool, c.Status, "ok")
+		}
+	}
+}

--- a/cmd/updater/history.go
+++ b/cmd/updater/history.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/json"
 	"fmt"
 	"sort"
 	"text/tabwriter"
@@ -9,7 +10,10 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var flagHistoryLimit int
+var (
+	flagHistoryLimit int
+	flagHistoryJSON  bool
+)
 
 var historyCmd = &cobra.Command{
 	Use:   "history",
@@ -19,6 +23,7 @@ var historyCmd = &cobra.Command{
 
 func init() {
 	historyCmd.Flags().IntVarP(&flagHistoryLimit, "limit", "n", 20, "maximum number of entries to show")
+	historyCmd.Flags().BoolVar(&flagHistoryJSON, "json", false, "output as JSON")
 	rootCmd.AddCommand(historyCmd)
 }
 
@@ -29,6 +34,10 @@ func runHistory(cmd *cobra.Command, args []string) error {
 	}
 
 	if len(entries) == 0 {
+		if flagHistoryJSON {
+			fmt.Fprintln(cmd.OutOrStdout(), "[]")
+			return nil
+		}
 		fmt.Fprintln(cmd.OutOrStdout(), "No update history yet.")
 		return nil
 	}
@@ -43,11 +52,19 @@ func runHistory(cmd *cobra.Command, args []string) error {
 		entries = entries[:flagHistoryLimit]
 	}
 
+	if flagHistoryJSON {
+		enc := json.NewEncoder(cmd.OutOrStdout())
+		enc.SetIndent("", "  ")
+		return enc.Encode(entries)
+	}
+
 	w := tabwriter.NewWriter(cmd.OutOrStdout(), 0, 4, 2, ' ', 0)
 	fmt.Fprintln(w, "DATE\tAPP\tFROM\tTO\tSOURCE\tSTATUS")
 	for _, e := range entries {
 		status := "ok"
-		if !e.Success {
+		if e.RolledBack {
+			status = "ROLLED BACK"
+		} else if !e.Success {
 			status = "FAILED"
 		}
 		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\n",

--- a/cmd/updater/history_test.go
+++ b/cmd/updater/history_test.go
@@ -1,0 +1,113 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/luzhengda/updater/internal/history"
+	"github.com/spf13/cobra"
+)
+
+func writeTestHistory(t *testing.T, entries []history.Entry) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "history.json")
+	data, err := json.MarshalIndent(entries, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal history: %v", err)
+	}
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		t.Fatalf("write history: %v", err)
+	}
+	return path
+}
+
+func sampleEntries(n int) []history.Entry {
+	names := []string{"Firefox", "Chrome", "Slack", "VSCode", "iTerm2"}
+	entries := make([]history.Entry, n)
+	for i := range n {
+		entries[i] = history.Entry{
+			AppName:     names[i%len(names)],
+			BundleID:    "com.test." + names[i%len(names)],
+			FromVersion: "1.0",
+			ToVersion:   "2.0",
+			Source:      "sparkle",
+			Timestamp:   time.Date(2025, 1, 1+i, 12, 0, 0, 0, time.UTC),
+			Success:     true,
+		}
+	}
+	return entries
+}
+
+func runHistoryWithPath(t *testing.T, path string, limit int, asJSON bool) string {
+	t.Helper()
+
+	origDefault := history.DefaultPath
+	history.DefaultPath = func() string { return path }
+	defer func() { history.DefaultPath = origDefault }()
+
+	origLimit := flagHistoryLimit
+	origJSON := flagHistoryJSON
+	defer func() {
+		flagHistoryLimit = origLimit
+		flagHistoryJSON = origJSON
+	}()
+	flagHistoryLimit = limit
+	flagHistoryJSON = asJSON
+
+	var buf bytes.Buffer
+	cmd := &cobra.Command{}
+	cmd.SetOut(&buf)
+
+	if err := runHistory(cmd, nil); err != nil {
+		t.Fatalf("runHistory: %v", err)
+	}
+	return buf.String()
+}
+
+func TestRunHistory_JSON(t *testing.T) {
+	entries := sampleEntries(3)
+	path := writeTestHistory(t, entries)
+
+	out := runHistoryWithPath(t, path, 0, true)
+
+	var got []history.Entry
+	if err := json.Unmarshal([]byte(out), &got); err != nil {
+		t.Fatalf("invalid JSON output: %v\nraw: %s", err, out)
+	}
+	if len(got) != 3 {
+		t.Errorf("expected 3 entries, got %d", len(got))
+	}
+}
+
+func TestRunHistory_JSON_Empty(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "nonexistent.json")
+
+	out := runHistoryWithPath(t, path, 20, true)
+
+	var got []history.Entry
+	if err := json.Unmarshal([]byte(out), &got); err != nil {
+		t.Fatalf("invalid JSON output: %v\nraw: %s", err, out)
+	}
+	if len(got) != 0 {
+		t.Errorf("expected 0 entries, got %d", len(got))
+	}
+}
+
+func TestRunHistory_JSON_WithLimit(t *testing.T) {
+	entries := sampleEntries(5)
+	path := writeTestHistory(t, entries)
+
+	out := runHistoryWithPath(t, path, 2, true)
+
+	var got []history.Entry
+	if err := json.Unmarshal([]byte(out), &got); err != nil {
+		t.Fatalf("invalid JSON output: %v\nraw: %s", err, out)
+	}
+	if len(got) != 2 {
+		t.Errorf("expected 2 entries, got %d", len(got))
+	}
+}

--- a/cmd/updater/notify.go
+++ b/cmd/updater/notify.go
@@ -11,6 +11,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var flagInteractive bool
+
 var notifyCmd = &cobra.Command{
 	Use:    "notify",
 	Short:  "Check for updates and send a macOS notification",
@@ -19,6 +21,7 @@ var notifyCmd = &cobra.Command{
 }
 
 func init() {
+	notifyCmd.Flags().BoolVar(&flagInteractive, "interactive", false, "show dialog with action buttons")
 	rootCmd.AddCommand(notifyCmd)
 }
 
@@ -54,7 +57,7 @@ func runNotify(cmd *cobra.Command, _ []string) error {
 	checkers := buildCheckers(runner, cfg.ResolveGitHubToken())
 	results := checkAll(ctx, apps, checkers, cfg.MaxConcurrentOrDefault())
 
-	// Collect updatable apps.
+	// Collect updatable apps (including notify-only policy apps).
 	var updatable []*checker.UpdateResult
 	for _, r := range results {
 		if r.HasUpdate && r.Error == nil && !cfg.IsPinned(r.App.BundleID) {
@@ -68,6 +71,10 @@ func runNotify(cmd *cobra.Command, _ []string) error {
 
 	body := buildNotificationBody(updatable)
 	subtitle := buildNotificationSubtitle(updatable)
+
+	if flagInteractive {
+		return sendInteractiveNotification(ctx, runner, len(updatable), body)
+	}
 	return sendNotification(ctx, runner, len(updatable), body, subtitle)
 }
 
@@ -118,6 +125,32 @@ func sendNotification(ctx context.Context, runner checker.CmdRunner, count int, 
 	_, err := runner.Run(ctx, "osascript", "-e", script)
 	if err != nil {
 		return fmt.Errorf("failed to send notification: %w", err)
+	}
+	return nil
+}
+
+// sendInteractiveNotification shows a dialog with action buttons via osascript.
+func sendInteractiveNotification(ctx context.Context, runner checker.CmdRunner, count int, body string) error {
+	title := fmt.Sprintf("%d update(s) available", count)
+
+	binaryPath, err := os.Executable()
+	if err != nil {
+		binaryPath = "updater"
+	}
+
+	script := fmt.Sprintf(
+		`set answer to display dialog "%s" with title "%s" buttons {"Dismiss", "Open Updater"} default button "Dismiss" giving up after 30
+if button returned of answer is "Open Updater" then
+    do shell script "%s ui &>/dev/null &"
+end if`,
+		escapeAppleScript(body),
+		escapeAppleScript(title),
+		escapeAppleScript(binaryPath),
+	)
+
+	_, err = runner.Run(ctx, "osascript", "-e", script)
+	if err != nil {
+		return fmt.Errorf("failed to show interactive notification: %w", err)
 	}
 	return nil
 }

--- a/cmd/updater/notify_test.go
+++ b/cmd/updater/notify_test.go
@@ -176,3 +176,46 @@ func (r *captureNotifyRunner) Run(_ context.Context, name string, args ...string
 	r.args = args
 	return nil, nil
 }
+
+func TestSendInteractiveNotification(t *testing.T) {
+	captureRunner := &captureNotifyRunner{}
+
+	err := sendInteractiveNotification(context.Background(), captureRunner, 3, "Firefox, Chrome, Safari")
+	if err != nil {
+		t.Fatalf("sendInteractiveNotification failed: %v", err)
+	}
+
+	if captureRunner.name != "osascript" {
+		t.Errorf("expected osascript, got %s", captureRunner.name)
+	}
+	if len(captureRunner.args) < 2 {
+		t.Fatal("expected at least 2 args")
+	}
+	script := captureRunner.args[1]
+	if !strings.Contains(script, "display dialog") {
+		t.Error("expected 'display dialog' in interactive script")
+	}
+	if !strings.Contains(script, "Open Updater") {
+		t.Error("expected 'Open Updater' button in script")
+	}
+	if !strings.Contains(script, "Dismiss") {
+		t.Error("expected 'Dismiss' button in script")
+	}
+}
+
+func TestSendNotification_PassiveDefault(t *testing.T) {
+	captureRunner := &captureNotifyRunner{}
+
+	err := sendNotification(context.Background(), captureRunner, 1, "Firefox (120→121)", "")
+	if err != nil {
+		t.Fatalf("sendNotification failed: %v", err)
+	}
+
+	script := captureRunner.args[1]
+	if !strings.Contains(script, "display notification") {
+		t.Error("expected 'display notification' (passive) for default mode")
+	}
+	if strings.Contains(script, "display dialog") {
+		t.Error("passive mode should NOT use 'display dialog'")
+	}
+}

--- a/cmd/updater/policy.go
+++ b/cmd/updater/policy.go
@@ -1,0 +1,75 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/luzhengda/updater/internal/config"
+	"github.com/spf13/cobra"
+)
+
+var policyCmd = &cobra.Command{
+	Use:   "policy <app-name> <auto|manual|notify-only|clear>",
+	Short: "Set update policy for an app",
+	Long: `Set per-app update policies to control how updates are handled.
+
+Policies:
+  auto         Always update automatically (--auto and --all)
+  manual       Only update when explicitly named
+  notify-only  Show in notifications but skip in --all and --auto
+  clear        Remove the policy (revert to default behavior)`,
+	Args: cobra.ExactArgs(2),
+	RunE: runPolicy,
+}
+
+func init() {
+	rootCmd.AddCommand(policyCmd)
+}
+
+func runPolicy(cmd *cobra.Command, args []string) error {
+	appName := args[0]
+	policy := strings.ToLower(args[1])
+
+	validPolicies := map[string]bool{
+		config.PolicyAuto: true, config.PolicyManual: true, config.PolicyNotifyOnly: true, "clear": true,
+	}
+	if !validPolicies[policy] {
+		return fmt.Errorf("invalid policy %q: must be auto, manual, notify-only, or clear", policy)
+	}
+
+	cfgPath := config.DefaultPath()
+	cfg, err := config.Load(cfgPath)
+	if err != nil {
+		return fmt.Errorf("failed to load config: %w", err)
+	}
+
+	// Find app by name.
+	apps, err := discoverApps()
+	if err != nil {
+		return err
+	}
+
+	var bundleID string
+	for _, a := range apps {
+		if strings.EqualFold(a.Name, appName) {
+			bundleID = a.BundleID
+			break
+		}
+	}
+	if bundleID == "" {
+		return fmt.Errorf("app %q not found. Run 'updater scan' to see available apps", appName)
+	}
+
+	if policy == "clear" {
+		cfg.RemovePolicy(bundleID)
+		fmt.Fprintf(cmd.OutOrStdout(), "Cleared policy for %s\n", appName)
+	} else {
+		cfg.SetPolicy(bundleID, policy)
+		fmt.Fprintf(cmd.OutOrStdout(), "Set policy for %s to %s\n", appName, policy)
+	}
+
+	if err := cfg.Save(cfgPath); err != nil {
+		return fmt.Errorf("failed to save config: %w", err)
+	}
+	return nil
+}

--- a/cmd/updater/ui.go
+++ b/cmd/updater/ui.go
@@ -10,6 +10,7 @@ import (
 	"github.com/luzhengda/updater/internal/backup"
 	"github.com/luzhengda/updater/internal/checker"
 	"github.com/luzhengda/updater/internal/config"
+	"github.com/luzhengda/updater/internal/history"
 	"github.com/luzhengda/updater/internal/installer"
 	"github.com/luzhengda/updater/internal/tui"
 	"github.com/spf13/cobra"
@@ -80,7 +81,8 @@ func runUI(_ *cobra.Command, _ []string) error {
 	}
 
 	updateFn := func(ctx context.Context, result *checker.UpdateResult) error {
-		return executeUpdate(ctx, result, runner, bm, inst)
+		err, _ := executeUpdate(ctx, result, runner, bm, inst)
+		return err
 	}
 
 	scheduleFns := &tui.ScheduleFuncs{
@@ -103,7 +105,10 @@ func runUI(_ *cobra.Command, _ []string) error {
 		},
 	}
 
-	model := tui.NewModel(loadFn, checkFn, updateFn, scheduleFns, cfg, cfgPath)
+	historyFn := func() ([]history.Entry, error) {
+		return history.List(history.DefaultPath())
+	}
+	model := tui.NewModel(loadFn, checkFn, updateFn, scheduleFns, cfg, cfgPath, historyFn)
 	p := tea.NewProgram(model, tea.WithAltScreen())
 
 	if _, err := p.Run(); err != nil {

--- a/cmd/updater/update.go
+++ b/cmd/updater/update.go
@@ -105,6 +105,10 @@ func runUpdate(cmd *cobra.Command, args []string) error {
 			if autoSkipSources[r.Source] {
 				continue
 			}
+			policy := cfg.Policy(r.App.BundleID)
+			if policy == config.PolicyManual || policy == config.PolicyNotifyOnly {
+				continue
+			}
 			autoUpdatable = append(autoUpdatable, r)
 		}
 		updatable = autoUpdatable
@@ -145,10 +149,14 @@ func runUpdate(cmd *cobra.Command, args []string) error {
 			fmt.Fprintf(cmd.OutOrStdout(), "Skipping %s (pinned)\n", r.App.Name)
 			continue
 		}
+		if !isExplicit && cfg.Policy(r.App.BundleID) == config.PolicyNotifyOnly {
+			fmt.Fprintf(cmd.OutOrStdout(), "Skipping %s (notify-only)\n", r.App.Name)
+			continue
+		}
 		fmt.Fprintf(cmd.OutOrStdout(), "Updating %s (%s -> %s) via %s...\n",
 			r.App.Name, r.CurrentVersion, r.LatestVersion, r.Source)
 
-		updateErr := executeUpdate(ctx, r, runner, bm, inst)
+		updateErr, rolledBack := executeUpdate(ctx, r, runner, bm, inst)
 		if errors.Is(updateErr, checker.ErrOpenedExternally) {
 			// Not an error — just opened externally for the user to handle.
 		} else if updateErr != nil {
@@ -164,6 +172,7 @@ func runUpdate(cmd *cobra.Command, args []string) error {
 			Source:      r.Source,
 			Timestamp:   time.Now(),
 			Success:     updateErr == nil || errors.Is(updateErr, checker.ErrOpenedExternally),
+			RolledBack:  rolledBack,
 		})
 	}
 
@@ -172,7 +181,8 @@ func runUpdate(cmd *cobra.Command, args []string) error {
 
 // executeUpdate performs the actual update for a single app.
 // It backs up the current version before updating when possible.
-func executeUpdate(ctx context.Context, r *checker.UpdateResult, runner checker.CmdRunner, bm *backup.Manager, inst *installer.Installer) error {
+// Returns the error (if any) and whether a rollback was performed.
+func executeUpdate(ctx context.Context, r *checker.UpdateResult, runner checker.CmdRunner, bm *backup.Manager, inst *installer.Installer) (error, bool) {
 	// Backup before update (non-fatal on failure).
 	if bm != nil && r.App.Path != "" {
 		if err := bm.Backup(ctx, r.App.Name, r.App.BundleID, r.CurrentVersion, r.App.Path); err != nil {
@@ -185,20 +195,20 @@ func executeUpdate(ctx context.Context, r *checker.UpdateResult, runner checker.
 	switch r.Source {
 	case "brew":
 		if r.App.CaskName == "" {
-			return fmt.Errorf("no cask name for %s", r.App.Name)
+			return fmt.Errorf("no cask name for %s", r.App.Name), false
 		}
 		if !r.App.InstalledViaBrew {
 			openForSelfUpdate(ctx, r.App, runner)
-			return checker.ErrOpenedExternally
+			return checker.ErrOpenedExternally, false
 		}
-		return brewUpgrade(ctx, r.App, runner)
+		return brewUpgrade(ctx, r.App, runner), false
 
 	case "brew-info":
 		if r.App.InstalledViaBrew && r.App.CaskName != "" {
-			return brewUpgrade(ctx, r.App, runner)
+			return brewUpgrade(ctx, r.App, runner), false
 		}
 		openForSelfUpdate(ctx, r.App, runner)
-		return checker.ErrOpenedExternally
+		return checker.ErrOpenedExternally, false
 
 	case "mas":
 		if r.App.MASID != "" {
@@ -206,36 +216,36 @@ func executeUpdate(ctx context.Context, r *checker.UpdateResult, runner checker.
 			if err != nil {
 				fmt.Fprintf(os.Stderr, "  mas upgrade failed, opening App Store: %v\n", err)
 				_, _ = runner.Run(ctx, "open", "macappstore://showUpdatesPage")
-				return checker.ErrOpenedExternally
+				return checker.ErrOpenedExternally, false
 			}
 			fmt.Println(string(output))
-			return nil
+			return nil, false
 		}
 		_, _ = runner.Run(ctx, "open", "macappstore://showUpdatesPage")
-		return checker.ErrOpenedExternally
+		return checker.ErrOpenedExternally, false
 
 	case "formula":
 		if r.App.FormulaName == "" {
-			return fmt.Errorf("no formula name for %s", r.App.Name)
+			return fmt.Errorf("no formula name for %s", r.App.Name), false
 		}
 		output, err := runner.Run(ctx, "brew", "upgrade", r.App.FormulaName)
 		if err != nil {
-			return fmt.Errorf("failed to upgrade formula %s: %w", r.App.FormulaName, err)
+			return fmt.Errorf("failed to upgrade formula %s: %w", r.App.FormulaName, err), false
 		}
 		fmt.Println(string(output))
-		return nil
+		return nil, false
 
 	case "system":
 		_, err := runner.Run(ctx, "open", "x-apple.systempreferences:com.apple.Software-Update-Settings.extension")
 		if err != nil {
-			return fmt.Errorf("failed to open Software Update settings: %w", err)
+			return fmt.Errorf("failed to open Software Update settings: %w", err), false
 		}
-		return checker.ErrOpenedExternally
+		return checker.ErrOpenedExternally, false
 
 	case "sparkle", "github":
 		if r.DownloadURL == "" {
 			fmt.Println("  No download URL available. Check the app for in-app updates.")
-			return nil
+			return nil, false
 		}
 
 		// Try direct install if installer is available.
@@ -247,17 +257,22 @@ func executeUpdate(ctx context.Context, r *checker.UpdateResult, runner checker.
 					fmt.Printf("  Reopening %s...\n", r.App.Name)
 					_, _ = runner.Run(ctx, "open", "-a", r.App.Path)
 				}
-				return nil
+				return nil, false
 			}
+			// Attempt rollback on failed direct install.
+			rolledBack := rollbackAfterFailedInstall(ctx, bm, r.App.Name)
 			fmt.Fprintf(os.Stderr, "  direct install failed, falling back to browser: %v\n", err)
+			if rolledBack {
+				return err, true
+			}
 		}
 
 		// Fallback: open in browser.
 		_, err := runner.Run(ctx, "open", r.DownloadURL)
 		if err != nil {
-			return fmt.Errorf("failed to open download URL: %w", err)
+			return fmt.Errorf("failed to open download URL: %w", err), false
 		}
-		return checker.ErrOpenedExternally
+		return checker.ErrOpenedExternally, false
 
 	case "electron":
 		// Try direct install from ElectronUpdateURL if available.
@@ -269,29 +284,48 @@ func executeUpdate(ctx context.Context, r *checker.UpdateResult, runner checker.
 					fmt.Printf("  Reopening %s...\n", r.App.Name)
 					_, _ = runner.Run(ctx, "open", "-a", r.App.Path)
 				}
-				return nil
+				return nil, false
 			}
+			// Attempt rollback on failed direct install.
+			rolledBack := rollbackAfterFailedInstall(ctx, bm, r.App.Name)
 			fmt.Fprintf(os.Stderr, "  direct install failed, opening app for self-update: %v\n", err)
+			if rolledBack {
+				return err, true
+			}
 		}
 		// Fallback: open app for self-update.
 		_, _ = runner.Run(ctx, "open", "-a", r.App.Path)
-		return checker.ErrOpenedExternally
+		return checker.ErrOpenedExternally, false
 
 	case "setapp":
 		_, _ = runner.Run(ctx, "open", "-a", "/Applications/Setapp.app")
-		return checker.ErrOpenedExternally
+		return checker.ErrOpenedExternally, false
 
 	case "toolbox":
 		_, _ = runner.Run(ctx, "open", "-a", "JetBrains Toolbox")
-		return checker.ErrOpenedExternally
+		return checker.ErrOpenedExternally, false
 
 	case "adobe":
 		_, _ = runner.Run(ctx, "open", "-a", "/Applications/Adobe Creative Cloud/Adobe Creative Cloud.app")
-		return checker.ErrOpenedExternally
+		return checker.ErrOpenedExternally, false
 
 	default:
-		return fmt.Errorf("unsupported update source: %s", r.Source)
+		return fmt.Errorf("unsupported update source: %s", r.Source), false
 	}
+}
+
+// rollbackAfterFailedInstall attempts to restore an app from backup after a failed install.
+func rollbackAfterFailedInstall(ctx context.Context, bm *backup.Manager, appName string) bool {
+	if bm == nil || !bm.HasBackup(appName) {
+		return false
+	}
+	fmt.Fprintf(os.Stderr, "  Attempting rollback for %s...\n", appName)
+	if err := bm.Restore(ctx, appName); err != nil {
+		fmt.Fprintf(os.Stderr, "  Rollback failed: %v\n", err)
+		return false
+	}
+	fmt.Printf("  Rolled back %s to previous version\n", appName)
+	return true
 }
 
 // brewUpgrade quits the app if running, runs brew upgrade, and reopens it.

--- a/cmd/updater/update_test.go
+++ b/cmd/updater/update_test.go
@@ -1,0 +1,130 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/luzhengda/updater/internal/app"
+	"github.com/luzhengda/updater/internal/backup"
+	"github.com/luzhengda/updater/internal/checker"
+)
+
+// createFakeBackup manually creates a backup directory structure that
+// backup.Manager.HasBackup/Restore can find.
+func createFakeBackup(t *testing.T, baseDir, appName, appPath string) {
+	t.Helper()
+	safeName := appName // backup uses sanitizeName (lowercase)
+	timestamp := time.Now().Format("20060102-150405")
+	backupDir := filepath.Join(baseDir, safeName, timestamp)
+	os.MkdirAll(backupDir, 0o755)
+
+	// Create fake backup app directory.
+	backupApp := filepath.Join(backupDir, filepath.Base(appPath))
+	os.MkdirAll(filepath.Join(backupApp, "Contents"), 0o755)
+	os.WriteFile(filepath.Join(backupApp, "Contents", "Info.plist"), []byte("<plist/>"), 0o644)
+
+	// Write metadata.
+	meta := backup.Metadata{
+		AppName:    appName,
+		BundleID:   "com.test.app",
+		Version:    "1.0",
+		BackupPath: backupApp,
+		BackupDate: time.Now(),
+		OrigPath:   appPath,
+	}
+	data, _ := json.MarshalIndent(meta, "", "  ")
+	os.WriteFile(filepath.Join(backupDir, "metadata.json"), data, 0o644)
+}
+
+func TestRollback_SparkleInstallFails(t *testing.T) {
+	tmpDir := t.TempDir()
+	backupDir := filepath.Join(tmpDir, "backups")
+	appPath := filepath.Join(tmpDir, "TestApp.app")
+	runner := &checker.MockCmdRunner{Output: nil}
+	bm := backup.NewManager(backupDir, 1, runner)
+
+	// Create fake backup structure.
+	createFakeBackup(t, backupDir, "testapp", appPath)
+
+	if !bm.HasBackup("TestApp") {
+		t.Fatal("expected HasBackup=true after creating backup")
+	}
+
+	// Rollback should succeed (Restore calls cp -a which the mock runner ignores but returns nil).
+	rolledBack := rollbackAfterFailedInstall(context.Background(), bm, "TestApp")
+	if !rolledBack {
+		t.Error("expected rollback to succeed")
+	}
+}
+
+func TestRollback_NotTriggeredForBrew(t *testing.T) {
+	tmpDir := t.TempDir()
+	backupDir := filepath.Join(tmpDir, "backups")
+	runner := &checker.MockCmdRunner{
+		Err: fmt.Errorf("brew upgrade failed"),
+	}
+	bm := backup.NewManager(backupDir, 1, runner)
+
+	result := &checker.UpdateResult{
+		App: &app.App{
+			Name:             "Firefox",
+			BundleID:         "org.mozilla.firefox",
+			CaskName:         "firefox",
+			InstalledViaBrew: true,
+			Path:             "/Applications/Firefox.app",
+		},
+		Source:         "brew",
+		CurrentVersion: "120.0",
+		LatestVersion:  "121.0",
+	}
+
+	err, rolledBack := executeUpdate(context.Background(), result, runner, bm, nil)
+	if err == nil {
+		t.Error("expected error from brew upgrade")
+	}
+	if rolledBack {
+		t.Error("brew failures should NOT trigger rollback")
+	}
+}
+
+func TestRollback_RestoreFails(t *testing.T) {
+	tmpDir := t.TempDir()
+	backupDir := filepath.Join(tmpDir, "backups")
+	appPath := filepath.Join(tmpDir, "TestApp.app")
+	runner := &checker.MockCmdRunner{
+		Err: fmt.Errorf("cp failed"),
+	}
+	bm := backup.NewManager(backupDir, 1, runner)
+
+	// Create backup structure, but runner will fail on Restore's cp.
+	createFakeBackup(t, backupDir, "testapp", appPath)
+
+	rolledBack := rollbackAfterFailedInstall(context.Background(), bm, "TestApp")
+	if rolledBack {
+		t.Error("expected rollback to fail when restore cp fails")
+	}
+}
+
+func TestRollback_NoBackup(t *testing.T) {
+	tmpDir := t.TempDir()
+	backupDir := filepath.Join(tmpDir, "backups")
+	runner := &checker.MockCmdRunner{Output: nil}
+	bm := backup.NewManager(backupDir, 1, runner)
+
+	rolledBack := rollbackAfterFailedInstall(context.Background(), bm, "NonExistentApp")
+	if rolledBack {
+		t.Error("expected rollback to return false when no backup exists")
+	}
+}
+
+func TestRollback_NilManager(t *testing.T) {
+	rolledBack := rollbackAfterFailedInstall(context.Background(), nil, "TestApp")
+	if rolledBack {
+		t.Error("expected rollback to return false with nil manager")
+	}
+}

--- a/internal/checker/integration_test.go
+++ b/internal/checker/integration_test.go
@@ -1,0 +1,158 @@
+package checker
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/luzhengda/updater/internal/app"
+)
+
+func TestSparkle_EndToEnd(t *testing.T) {
+	var serverURL string
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/xml")
+		xml := `<?xml version="1.0" encoding="utf-8"?>
+<rss version="2.0" xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle">
+  <channel>
+    <item>
+      <title>Version 3.0.0</title>
+      <enclosure url="` + serverURL + `/download/app.dmg" length="5000" type="application/octet-stream"
+        sparkle:version="300" sparkle:shortVersionString="3.0.0" />
+    </item>
+  </channel>
+</rss>`
+		w.Write([]byte(xml))
+	}))
+	defer ts.Close()
+	serverURL = ts.URL
+
+	sc := NewSparkleChecker(ts.Client())
+	a := &app.App{
+		Name:    "IntegrationApp",
+		Version: "2.0.0",
+		Source:  app.SourceSparkle,
+		FeedURL: ts.URL,
+	}
+
+	result, err := sc.Check(context.Background(), a)
+	if err != nil {
+		t.Fatalf("SparkleChecker.Check failed: %v", err)
+	}
+	if !result.HasUpdate {
+		t.Error("expected HasUpdate=true")
+	}
+	if result.LatestVersion != "3.0.0" {
+		t.Errorf("LatestVersion = %q, want %q", result.LatestVersion, "3.0.0")
+	}
+	if result.DownloadURL != serverURL+"/download/app.dmg" {
+		t.Errorf("DownloadURL = %q, want %q", result.DownloadURL, serverURL+"/download/app.dmg")
+	}
+	if result.Source != "sparkle" {
+		t.Errorf("Source = %q, want %q", result.Source, "sparkle")
+	}
+}
+
+func TestGitHub_EndToEnd(t *testing.T) {
+	release := GitHubRelease{
+		TagName: "v4.2.0",
+		Name:    "Release 4.2.0",
+		Body:    "Bug fixes and improvements",
+		Assets: []GitHubAsset{
+			{Name: "app-linux-amd64.tar.gz", DownloadURL: "https://example.com/linux.tar.gz"},
+			{Name: "app-macos-arm64.dmg", DownloadURL: "https://example.com/mac.dmg"},
+		},
+	}
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/repos/example/app/releases/latest" {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(release)
+	}))
+	defer ts.Close()
+
+	gc := NewGitHubChecker(ts.Client(), ts.URL, "")
+	a := &app.App{
+		Name:       "TestApp",
+		Version:    "4.0.0",
+		Source:     app.SourceGitHub,
+		GitHubRepo: "example/app",
+	}
+
+	result, err := gc.Check(context.Background(), a)
+	if err != nil {
+		t.Fatalf("GitHubChecker.Check failed: %v", err)
+	}
+	if !result.HasUpdate {
+		t.Error("expected HasUpdate=true")
+	}
+	if result.LatestVersion != "4.2.0" {
+		t.Errorf("LatestVersion = %q, want %q", result.LatestVersion, "4.2.0")
+	}
+	if result.DownloadURL != "https://example.com/mac.dmg" {
+		t.Errorf("DownloadURL = %q, want %q", result.DownloadURL, "https://example.com/mac.dmg")
+	}
+	if result.ReleaseNotes != "Bug fixes and improvements" {
+		t.Errorf("ReleaseNotes = %q, want %q", result.ReleaseNotes, "Bug fixes and improvements")
+	}
+}
+
+func TestSparkle_MultipleItems_OSFiltering(t *testing.T) {
+	orig := getMacOSVersionFn
+	getMacOSVersionFn = func() string { return "15.0" }
+	defer func() { getMacOSVersionFn = orig }()
+
+	xml := `<?xml version="1.0" encoding="utf-8"?>
+<rss version="2.0" xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle">
+  <channel>
+    <item>
+      <title>Version 4.0 (macOS 16+)</title>
+      <sparkle:minimumSystemVersion>16.0</sparkle:minimumSystemVersion>
+      <enclosure url="https://example.com/v4.dmg" sparkle:shortVersionString="4.0.0" sparkle:version="400" />
+    </item>
+    <item>
+      <title>Version 3.0 (macOS 14+)</title>
+      <sparkle:minimumSystemVersion>14.0</sparkle:minimumSystemVersion>
+      <sparkle:maximumSystemVersion>15.99</sparkle:maximumSystemVersion>
+      <enclosure url="https://example.com/v3.dmg" sparkle:shortVersionString="3.0.0" sparkle:version="300" />
+    </item>
+    <item>
+      <title>Version 2.0 (macOS 12+)</title>
+      <sparkle:minimumSystemVersion>12.0</sparkle:minimumSystemVersion>
+      <sparkle:maximumSystemVersion>14.99</sparkle:maximumSystemVersion>
+      <enclosure url="https://example.com/v2.dmg" sparkle:shortVersionString="2.0.0" sparkle:version="200" />
+    </item>
+  </channel>
+</rss>`
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/xml")
+		w.Write([]byte(xml))
+	}))
+	defer ts.Close()
+
+	sc := NewSparkleChecker(ts.Client())
+	a := &app.App{
+		Name:    "MultiItemApp",
+		Version: "2.0.0",
+		Source:  app.SourceSparkle,
+		FeedURL: ts.URL,
+	}
+
+	result, err := sc.Check(context.Background(), a)
+	if err != nil {
+		t.Fatalf("Check failed: %v", err)
+	}
+	// macOS 15.0 should pick v3.0 (min 14.0, max 15.99), not v4.0 (min 16.0)
+	if result.LatestVersion != "3.0.0" {
+		t.Errorf("LatestVersion = %q, want %q (should filter by OS)", result.LatestVersion, "3.0.0")
+	}
+	if !result.HasUpdate {
+		t.Error("expected HasUpdate=true")
+	}
+}

--- a/internal/checker/sparkle.go
+++ b/internal/checker/sparkle.go
@@ -98,7 +98,7 @@ func (s *SparkleChecker) Check(ctx context.Context, a *app.App) (*UpdateResult, 
 
 	// Find the best matching item: filter by macOS version, pick the last
 	// compatible item (feeds often list oldest first, newest last, or newest first).
-	macOSVersion := getMacOSVersion()
+	macOSVersion := getMacOSVersionFn()
 	item := findBestItem(rss.Channel.Items, macOSVersion)
 
 	// Extract version: prefer enclosure attributes (most common in real feeds),
@@ -147,7 +147,7 @@ func findBestItem(items []sparkleItem, macOSVersion string) sparkleItem {
 			}
 		}
 		if item.MaxSystemVersion != "" && macOSVersion != "" {
-			if version.IsNewer(macOSVersion, item.MaxSystemVersion) {
+			if version.IsNewer(item.MaxSystemVersion, macOSVersion) {
 				continue
 			}
 		}
@@ -177,8 +177,9 @@ func findBestItem(items []sparkleItem, macOSVersion string) sparkleItem {
 	return best
 }
 
-// getMacOSVersion returns the current macOS version (e.g., "15.3").
-func getMacOSVersion() string {
+// getMacOSVersionFn returns the current macOS version (e.g., "15.3").
+// It is a variable so tests can override it.
+var getMacOSVersionFn = func() string {
 	out, err := exec.Command("sw_vers", "-productVersion").Output()
 	if err != nil {
 		return ""

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -9,6 +9,13 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+// Policy constants for per-app update policies.
+const (
+	PolicyAuto       = "auto"
+	PolicyManual     = "manual"
+	PolicyNotifyOnly = "notify-only"
+)
+
 // Config holds the user configuration for the updater.
 type Config struct {
 	IgnoredApps    []string          `yaml:"ignored_apps"`
@@ -21,6 +28,7 @@ type Config struct {
 	ScheduleOffered  bool              `yaml:"schedule_offered"`
 	ScheduleInterval int               `yaml:"schedule_interval"`
 	LastChecked      time.Time         `yaml:"last_checked,omitempty"`
+	Policies         map[string]string `yaml:"policies,omitempty"` // bundleID → "auto"|"manual"|"notify-only"
 	ignoredSet       map[string]bool   `yaml:"-"`
 	pinnedSet        map[string]bool   `yaml:"-"`
 }
@@ -168,6 +176,28 @@ func (c *Config) Unpin(bundleID string) {
 	c.PinnedApps = filtered
 }
 
+// Policy returns the update policy for the given bundle ID.
+// Returns empty string if no policy is set (defaults to normal behavior).
+func (c *Config) Policy(bundleID string) string {
+	if c.Policies == nil {
+		return ""
+	}
+	return c.Policies[bundleID]
+}
+
+// SetPolicy sets the update policy for the given bundle ID.
+func (c *Config) SetPolicy(bundleID, policy string) {
+	if c.Policies == nil {
+		c.Policies = make(map[string]string)
+	}
+	c.Policies[bundleID] = policy
+}
+
+// RemovePolicy removes the update policy for the given bundle ID.
+func (c *Config) RemovePolicy(bundleID string) {
+	delete(c.Policies, bundleID)
+}
+
 // Merge merges an imported config into the current one and returns the result.
 // Lists are unioned (deduplicated), maps are merged (imported overrides current),
 // and non-zero scalars from imported override current values.
@@ -181,6 +211,7 @@ func Merge(current, imported *Config) *Config {
 	// Merge maps: imported overrides current.
 	result.GitHubMappings = mergeMaps(current.GitHubMappings, imported.GitHubMappings)
 	result.CaskMappings = mergeMaps(current.CaskMappings, imported.CaskMappings)
+	result.Policies = mergeMaps(current.Policies, imported.Policies)
 
 	// Non-zero scalar overrides.
 	if imported.GitHubToken != "" {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -486,3 +486,70 @@ func TestMerge_ScalarOverride(t *testing.T) {
 		t.Errorf("ScheduleInterval = %d, want 24 (zero import should not override)", result.ScheduleInterval)
 	}
 }
+
+func TestPolicy_GetSetRemove(t *testing.T) {
+	cfg := defaultConfig()
+
+	// Default: no policy.
+	if got := cfg.Policy("com.example.app"); got != "" {
+		t.Errorf("Policy() = %q, want empty", got)
+	}
+
+	// Set policy.
+	cfg.SetPolicy("com.example.app", PolicyNotifyOnly)
+	if got := cfg.Policy("com.example.app"); got != PolicyNotifyOnly {
+		t.Errorf("Policy() = %q, want %q", got, PolicyNotifyOnly)
+	}
+
+	// Override policy.
+	cfg.SetPolicy("com.example.app", PolicyManual)
+	if got := cfg.Policy("com.example.app"); got != PolicyManual {
+		t.Errorf("Policy() = %q, want %q", got, PolicyManual)
+	}
+
+	// Remove policy.
+	cfg.RemovePolicy("com.example.app")
+	if got := cfg.Policy("com.example.app"); got != "" {
+		t.Errorf("Policy() = %q, want empty after remove", got)
+	}
+
+	// Remove non-existent (no panic).
+	cfg.RemovePolicy("com.example.nonexistent")
+}
+
+func TestPolicy_DefaultEmpty(t *testing.T) {
+	cfg := &Config{}
+	if got := cfg.Policy("com.example.any"); got != "" {
+		t.Errorf("Policy() on nil map = %q, want empty", got)
+	}
+}
+
+func TestMerge_Policies(t *testing.T) {
+	current := &Config{
+		Policies: map[string]string{
+			"com.a": PolicyAuto,
+			"com.b": PolicyManual,
+		},
+	}
+	current.buildIgnoredSet()
+	current.buildPinnedSet()
+
+	imported := &Config{
+		Policies: map[string]string{
+			"com.b": PolicyNotifyOnly, // override
+			"com.c": PolicyAuto,       // new
+		},
+	}
+
+	result := Merge(current, imported)
+
+	if got := result.Policy("com.a"); got != PolicyAuto {
+		t.Errorf("Policy(com.a) = %q, want %q", got, PolicyAuto)
+	}
+	if got := result.Policy("com.b"); got != PolicyNotifyOnly {
+		t.Errorf("Policy(com.b) = %q, want %q (imported should override)", got, PolicyNotifyOnly)
+	}
+	if got := result.Policy("com.c"); got != PolicyAuto {
+		t.Errorf("Policy(com.c) = %q, want %q", got, PolicyAuto)
+	}
+}

--- a/internal/history/history.go
+++ b/internal/history/history.go
@@ -17,10 +17,12 @@ type Entry struct {
 	Source      string    `json:"source"`
 	Timestamp   time.Time `json:"timestamp"`
 	Success     bool      `json:"success"`
+	RolledBack  bool      `json:"rolled_back,omitempty"`
 }
 
 // DefaultPath returns the default history file path (~/.local/share/updater/history.json).
-func DefaultPath() string {
+// It is a variable so tests can override it.
+var DefaultPath = func() string {
 	home, err := os.UserHomeDir()
 	if err != nil {
 		return ""

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sort"
 	"strings"
 	"time"
 
@@ -15,6 +16,7 @@ import (
 	"github.com/luzhengda/updater/internal/app"
 	"github.com/luzhengda/updater/internal/checker"
 	"github.com/luzhengda/updater/internal/config"
+	"github.com/luzhengda/updater/internal/history"
 )
 
 // CheckFunc checks all apps for updates and returns results.
@@ -45,6 +47,9 @@ type ScheduleFuncs struct {
 	Remove  func(ctx context.Context) error
 }
 
+// HistoryFunc loads update history entries.
+type HistoryFunc func() ([]history.Entry, error)
+
 // row represents a single row in the TUI table.
 type row struct {
 	app      *app.App
@@ -66,6 +71,11 @@ type checkDoneMsg struct {
 type updateDoneMsg struct {
 	index int
 	err   error
+}
+
+type historyLoadedMsg struct {
+	entries []history.Entry
+	err     error
 }
 
 type scheduleCheckMsg struct{ status ScheduleStatus }
@@ -109,6 +119,10 @@ type Model struct {
 	searchMode     bool
 	searchInput    textinput.Model
 	searchQuery    string
+	historyFn      HistoryFunc
+	showHistory    bool
+	historyEntries []history.Entry
+	historyOffset  int
 }
 
 // NewModel creates a new TUI model that launches instantly.
@@ -116,7 +130,7 @@ type Model struct {
 // checkFn runs after loading to check for updates.
 // updateFn executes updates for individual apps.
 // scheduleFns, cfg, and cfgPath are optional — pass nil/empty to disable scheduler UI.
-func NewModel(loadFn LoadFunc, checkFn CheckFunc, updateFn UpdateFunc, scheduleFns *ScheduleFuncs, cfg *config.Config, cfgPath string) Model {
+func NewModel(loadFn LoadFunc, checkFn CheckFunc, updateFn UpdateFunc, scheduleFns *ScheduleFuncs, cfg *config.Config, cfgPath string, historyFn ...HistoryFunc) Model {
 	s := spinner.New()
 	s.Spinner = spinner.Dot
 	s.Style = lipgloss.NewStyle().Foreground(colorCyan)
@@ -125,6 +139,11 @@ func NewModel(loadFn LoadFunc, checkFn CheckFunc, updateFn UpdateFunc, scheduleF
 	ti.Placeholder = "search..."
 	ti.Prompt = "/ "
 	ti.CharLimit = 64
+
+	var hFn HistoryFunc
+	if len(historyFn) > 0 {
+		hFn = historyFn[0]
+	}
 
 	return Model{
 		loading:     true,
@@ -141,6 +160,7 @@ func NewModel(loadFn LoadFunc, checkFn CheckFunc, updateFn UpdateFunc, scheduleF
 		cfg:         cfg,
 		cfgPath:     cfgPath,
 		searchInput: ti,
+		historyFn:   hFn,
 	}
 }
 
@@ -292,6 +312,15 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.saveLastChecked()
 		return m, nil
 
+	case historyLoadedMsg:
+		if msg.err != nil {
+			m.statusMsg = fmt.Sprintf("Error loading history: %v", msg.err)
+			m.showHistory = false
+		} else {
+			m.historyEntries = msg.entries
+		}
+		return m, nil
+
 	case scheduleCheckMsg:
 		m.scheduleStatus = msg.status
 		if !msg.status.Enabled && m.cfg != nil && !m.cfg.ScheduleOffered {
@@ -356,6 +385,11 @@ func (m Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m.handleScheduleKey(msg)
 	}
 
+	// History overlay.
+	if m.showHistory {
+		return m.handleHistoryKey(msg)
+	}
+
 	// In detail view, handle viewport scrolling and escape.
 	if m.showDetail {
 		return m.handleDetailKey(msg)
@@ -412,6 +446,8 @@ func (m Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		case " ":
 			m.toggleSelection()
 			return m, nil
+		case "h":
+			return m.openHistory()
 		case "/":
 			m.searchMode = true
 			m.searchInput.Focus()
@@ -876,6 +912,10 @@ func (m Model) View() string {
 		return m.viewSchedule()
 	}
 
+	if m.showHistory {
+		return m.viewHistory()
+	}
+
 	if m.showDetail {
 		return m.viewDetail()
 	}
@@ -1127,6 +1167,10 @@ func (m Model) renderStatusBar() string {
 		helpParts = append(helpParts, "s: schedule")
 	}
 
+	if m.historyFn != nil {
+		helpParts = append(helpParts, "h: history")
+	}
+
 	helpParts = append(helpParts, "/: search", "r: refresh", "q: quit")
 
 	// Append last-checked timestamp.
@@ -1142,6 +1186,145 @@ func (m Model) renderStatusBar() string {
 	}
 
 	return help + msg
+}
+
+// openHistory opens the history overlay and fires async load.
+func (m Model) openHistory() (tea.Model, tea.Cmd) {
+	if m.historyFn == nil {
+		m.statusMsg = "History not available"
+		return m, nil
+	}
+	m.showHistory = true
+	m.historyEntries = nil
+	m.historyOffset = 0
+	fn := m.historyFn
+	return m, func() tea.Msg {
+		entries, err := fn()
+		return historyLoadedMsg{entries: entries, err: err}
+	}
+}
+
+// handleHistoryKey processes keyboard input in the history overlay.
+func (m Model) handleHistoryKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	switch msg.Type {
+	case tea.KeyCtrlC:
+		return m, tea.Quit
+	case tea.KeyEsc:
+		m.showHistory = false
+		return m, nil
+	case tea.KeyDown:
+		m.historyOffset++
+		m.clampHistoryOffset()
+		return m, nil
+	case tea.KeyUp:
+		if m.historyOffset > 0 {
+			m.historyOffset--
+		}
+		return m, nil
+	case tea.KeyRunes:
+		switch string(msg.Runes) {
+		case "q", "h":
+			m.showHistory = false
+			return m, nil
+		case "j":
+			m.historyOffset++
+			m.clampHistoryOffset()
+			return m, nil
+		case "k":
+			if m.historyOffset > 0 {
+				m.historyOffset--
+			}
+			return m, nil
+		}
+	}
+	return m, nil
+}
+
+// clampHistoryOffset ensures the offset doesn't exceed the number of entries.
+func (m *Model) clampHistoryOffset() {
+	maxOffset := len(m.historyEntries) - m.historyVisibleRows()
+	if maxOffset < 0 {
+		maxOffset = 0
+	}
+	if m.historyOffset > maxOffset {
+		m.historyOffset = maxOffset
+	}
+}
+
+// historyVisibleRows returns how many history rows fit in the viewport.
+func (m Model) historyVisibleRows() int {
+	// Reserve: header (2) + column headers (1) + status bar (1) + padding (1) = 5
+	rows := m.height - 5
+	if rows < 1 {
+		rows = 1
+	}
+	return rows
+}
+
+// viewHistory renders the history overlay.
+func (m Model) viewHistory() string {
+	var b strings.Builder
+
+	b.WriteString(styleHeader.Render("Update History"))
+	b.WriteString("\n")
+
+	if m.historyEntries == nil {
+		b.WriteString(m.spinner.View())
+		b.WriteString(" Loading history...\n")
+		return b.String()
+	}
+
+	if len(m.historyEntries) == 0 {
+		b.WriteString(lipgloss.NewStyle().Foreground(colorGray).Render("  No update history yet."))
+		b.WriteString("\n")
+		b.WriteString(styleStatusBar.Render("h/esc/q: back"))
+		return b.String()
+	}
+
+	// Sort newest first.
+	entries := make([]history.Entry, len(m.historyEntries))
+	copy(entries, m.historyEntries)
+	sort.Slice(entries, func(i, j int) bool {
+		return entries[i].Timestamp.After(entries[j].Timestamp)
+	})
+
+	// Column headers.
+	b.WriteString(styleColumnHeader.Render(fmt.Sprintf("  %-12s  %-20s  %-22s  %s",
+		"DATE", "APP", "VERSION", "STATUS")))
+	b.WriteString("\n")
+
+	// Render visible rows.
+	visRows := m.historyVisibleRows()
+	end := m.historyOffset + visRows
+	if end > len(entries) {
+		end = len(entries)
+	}
+
+	for i := m.historyOffset; i < end; i++ {
+		e := entries[i]
+		status := styleUpToDate.Render("ok")
+		if !e.Success {
+			status = styleError.Render("FAILED")
+		}
+		b.WriteString(fmt.Sprintf("  %-12s  %-20s  %-10s → %-10s %s\n",
+			e.Timestamp.Format("2006-01-02"),
+			truncate(e.AppName, 20),
+			truncate(e.FromVersion, 10),
+			truncate(e.ToVersion, 10),
+			status,
+		))
+	}
+
+	// Scroll indicator.
+	if len(entries) > visRows {
+		b.WriteString(lipgloss.NewStyle().Foreground(colorGray).Render(
+			fmt.Sprintf("  showing %d-%d of %d", m.historyOffset+1, end, len(entries))))
+		b.WriteString("\n")
+	}
+
+	b.WriteString(styleStatusBar.Render("j/k: scroll | h/esc/q: back"))
+
+	return b.String()
 }
 
 // formatRelativeTime returns a human-readable relative time string.

--- a/internal/updater/integration_test.go
+++ b/internal/updater/integration_test.go
@@ -1,0 +1,98 @@
+package updater
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/luzhengda/updater/internal/app"
+	"github.com/luzhengda/updater/internal/checker"
+)
+
+func TestFallthrough_SparkleStale_ToBrewInfo(t *testing.T) {
+	// Sparkle feed returns a version older than installed (stale).
+	staleXML := `<?xml version="1.0" encoding="utf-8"?>
+<rss version="2.0" xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle">
+  <channel>
+    <item>
+      <enclosure url="https://example.com/old.dmg" sparkle:shortVersionString="2.0.0" sparkle:version="200" />
+    </item>
+  </channel>
+</rss>`
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/xml")
+		w.Write([]byte(staleXML))
+	}))
+	defer ts.Close()
+
+	// BrewInfo mock returns version 4.0.0
+	runner := &checker.MockCmdRunner{
+		Output: []byte(`{"casks":[{"token":"test-app","version":"4.0.0"}]}`),
+	}
+
+	a := &app.App{
+		Name:     "StaleApp",
+		Version:  "3.0.0", // installed v3, sparkle says v2 (stale)
+		Source:   app.SourceSparkle,
+		FeedURL:  ts.URL,
+		CaskName: "test-app",
+	}
+
+	checkers := []checker.Checker{
+		checker.NewSparkleChecker(ts.Client()),
+		checker.NewBrewInfoChecker(runner),
+	}
+
+	result := CheckWithFallthrough(context.Background(), a, checkers)
+	if result.Error != nil {
+		t.Fatalf("unexpected error: %v", result.Error)
+	}
+	if result.Source != "brew-info" {
+		t.Errorf("Source = %q, want %q (should fallthrough from stale sparkle)", result.Source, "brew-info")
+	}
+	if result.LatestVersion != "4.0.0" {
+		t.Errorf("LatestVersion = %q, want %q", result.LatestVersion, "4.0.0")
+	}
+	if !result.HasUpdate {
+		t.Error("expected HasUpdate=true")
+	}
+}
+
+func TestFallthrough_GitHub404_ToBrewInfo(t *testing.T) {
+	// GitHub returns 404.
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.NotFound(w, nil)
+	}))
+	defer ts.Close()
+
+	// BrewInfo mock returns version 2.0.0
+	runner := &checker.MockCmdRunner{
+		Output: []byte(`{"casks":[{"token":"missing-app","version":"2.0.0"}]}`),
+	}
+
+	a := &app.App{
+		Name:       "MissingApp",
+		Version:    "1.0.0",
+		Source:     app.SourceGitHub,
+		GitHubRepo: "example/missing-app",
+		CaskName:   "missing-app",
+	}
+
+	checkers := []checker.Checker{
+		checker.NewGitHubChecker(ts.Client(), ts.URL, ""),
+		checker.NewBrewInfoChecker(runner),
+	}
+
+	result := CheckWithFallthrough(context.Background(), a, checkers)
+	if result.Error != nil {
+		t.Fatalf("unexpected error: %v", result.Error)
+	}
+	if result.Source != "brew-info" {
+		t.Errorf("Source = %q, want %q (should fallthrough from GitHub 404)", result.Source, "brew-info")
+	}
+	if result.LatestVersion != "2.0.0" {
+		t.Errorf("LatestVersion = %q, want %q", result.LatestVersion, "2.0.0")
+	}
+}


### PR DESCRIPTION
## Summary
- **Release pipeline**: Add updater-menubar to goreleaser, universal binary support (arm64+x86_64)
- **JSON history**: `updater history --json` for machine-readable output
- **Integration tests**: httptest-based end-to-end tests for Sparkle, GitHub, and checker fallthrough
- **TUI history view**: Press `h` in TUI to view update history overlay with scrolling
- **Per-app policies**: `updater policy <app> <auto|manual|notify-only|clear>` — respected by `--auto` and `--all`
- **Interactive notifications**: `updater notify --interactive` shows dialog with "Open Updater" button
- **Doctor command**: `updater doctor` diagnostic checks (tools, config, backups, history, agents, network)
- **Automatic rollback**: Failed direct installs (sparkle/github/electron) auto-restore from backup
- **Bug fix**: Fixed OS version filtering in Sparkle checker (max version comparison was inverted)

## Test plan
- [ ] `go vet ./...` passes
- [ ] `go test -race ./...` passes (all 11 packages)
- [ ] `goreleaser build --snapshot --clean` produces universal binaries
- [ ] `updater history --json` outputs valid JSON
- [ ] `updater doctor` shows all diagnostic checks
- [ ] `updater policy Firefox auto` sets policy correctly
- [ ] TUI: press `h` shows history overlay
- [ ] `updater notify --interactive` shows dialog with buttons