### PR TITLE
feat: v0.7.0 — menubar UX, auto-update, bulk rollback, test coverage

### DIFF
--- a/cmd/updater-menubar/main.go
+++ b/cmd/updater-menubar/main.go
@@ -31,10 +31,11 @@ func onReady() {
 	systray.AddSeparator()
 	mQuit := systray.AddMenuItem("Quit", "Quit Updater")
 
-	// Track dynamic app menu items.
+	// Track dynamic app menu items and updatable results.
 	var (
-		mu       sync.Mutex
-		appItems []*systray.MenuItem
+		mu        sync.Mutex
+		appItems  []*systray.MenuItem
+		updatable []*checker.UpdateResult
 	)
 
 	// clearAppItems removes all dynamically added app menu items.
@@ -48,7 +49,8 @@ func onReady() {
 	}
 
 	// checkForUpdates runs update checks and populates the menu.
-	checkForUpdates := func() {
+	var checkForUpdates func()
+	checkForUpdates = func() {
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 		defer cancel()
 
@@ -83,10 +85,10 @@ func onReady() {
 		results := updater.CheckAll(ctx, apps, checkers, cfg.MaxConcurrentOrDefault())
 
 		// Collect updatable results.
-		var updatable []*checker.UpdateResult
+		var newUpdatable []*checker.UpdateResult
 		for _, r := range results {
 			if r.HasUpdate && r.Error == nil && !cfg.IsPinned(r.App.BundleID) {
-				updatable = append(updatable, r)
+				newUpdatable = append(newUpdatable, r)
 			}
 		}
 
@@ -94,6 +96,8 @@ func onReady() {
 		clearAppItems()
 		mu.Lock()
 		defer mu.Unlock()
+
+		updatable = newUpdatable
 
 		if len(updatable) == 0 {
 			systray.SetTitle("")
@@ -105,10 +109,13 @@ func onReady() {
 		mNoUpdates.Hide()
 		systray.SetTitle(fmt.Sprintf("%d", len(updatable)))
 
+		// Per-app menu items (indexed so Update All can reference them).
+		perAppItems := make([]*systray.MenuItem, 0, len(updatable))
 		for _, r := range updatable {
 			label := fmt.Sprintf("%s (%s \u2192 %s)", r.App.Name, r.CurrentVersion, r.LatestVersion)
 			item := systray.AddMenuItem(label, fmt.Sprintf("Update %s", r.App.Name))
 			appItems = append(appItems, item)
+			perAppItems = append(perAppItems, item)
 
 			// Launch update in background when clicked.
 			go func(appName string, menuItem *systray.MenuItem) {
@@ -122,6 +129,53 @@ func onReady() {
 				}
 			}(r.App.Name, item)
 		}
+
+		// Separator and "Update All" item.
+		sep := systray.AddMenuItem("", "")
+		sep.Disable()
+		appItems = append(appItems, sep)
+
+		updateAllItem := systray.AddMenuItem(
+			fmt.Sprintf("Update All (%d)", len(updatable)),
+			"Update all available apps",
+		)
+		appItems = append(appItems, updateAllItem)
+
+		// Snapshot updatable names and their menu items for the goroutine.
+		type appSnapshot struct {
+			name     string
+			menuItem *systray.MenuItem
+		}
+		snapshot := make([]appSnapshot, len(updatable))
+		for i, r := range updatable {
+			snapshot[i] = appSnapshot{name: r.App.Name, menuItem: perAppItems[i]}
+		}
+
+		go func() {
+			for range updateAllItem.ClickedCh {
+				updateAllItem.Disable()
+				updateAllItem.SetTitle("Updating...")
+
+				for _, s := range snapshot {
+					s.menuItem.SetTitle(fmt.Sprintf("Updating %s...", s.name))
+
+					cmd := exec.Command("updater", "update", s.name)
+					cmd.Stdout = os.Stdout
+					cmd.Stderr = os.Stderr
+					if err := cmd.Run(); err != nil {
+						fmt.Fprintf(os.Stderr, "update %s failed: %v\n", s.name, err)
+						s.menuItem.SetTitle(fmt.Sprintf("\u2717 %s (failed)", s.name))
+					} else {
+						s.menuItem.SetTitle(fmt.Sprintf("\u2713 %s (updated)", s.name))
+					}
+				}
+
+				updateAllItem.SetTitle("Done!")
+				time.Sleep(2 * time.Second)
+				go checkForUpdates()
+				return // Stop listening after one Update All cycle.
+			}
+		}()
 	}
 
 	// Initial check.

--- a/cmd/updater/notify.go
+++ b/cmd/updater/notify.go
@@ -2,16 +2,22 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"strings"
 
+	"github.com/luzhengda/updater/internal/backup"
 	"github.com/luzhengda/updater/internal/checker"
 	"github.com/luzhengda/updater/internal/config"
+	"github.com/luzhengda/updater/internal/installer"
 	"github.com/spf13/cobra"
 )
 
-var flagInteractive bool
+var (
+	flagInteractive bool
+	flagAutoUpdate  bool
+)
 
 var notifyCmd = &cobra.Command{
 	Use:    "notify",
@@ -22,6 +28,7 @@ var notifyCmd = &cobra.Command{
 
 func init() {
 	notifyCmd.Flags().BoolVar(&flagInteractive, "interactive", false, "show dialog with action buttons")
+	notifyCmd.Flags().BoolVar(&flagAutoUpdate, "auto-update", false, "automatically install safe updates after notification")
 	rootCmd.AddCommand(notifyCmd)
 }
 
@@ -75,7 +82,52 @@ func runNotify(cmd *cobra.Command, _ []string) error {
 	if flagInteractive {
 		return sendInteractiveNotification(ctx, runner, len(updatable), body)
 	}
-	return sendNotification(ctx, runner, len(updatable), body, subtitle)
+	if err := sendNotification(ctx, runner, len(updatable), body, subtitle); err != nil {
+		return err
+	}
+
+	if flagAutoUpdate {
+		autoUpdateAfterNotify(ctx, cfg, updatable)
+	}
+	return nil
+}
+
+// autoUpdateAfterNotify performs safe auto-updates for eligible apps after the
+// notification has been sent. It skips pinned, major-update, system/setapp/toolbox/adobe,
+// and manual/notify-only policy apps.
+func autoUpdateAfterNotify(ctx context.Context, cfg *config.Config, updatable []*checker.UpdateResult) {
+	runner := &checker.RealCmdRunner{}
+	bm := backup.NewManager(backup.DefaultBaseDir(), cfg.MaxBackupsOrDefault(), runner)
+	inst := installer.New(runner, nil)
+
+	autoSkipSources := map[string]bool{
+		"system": true, "setapp": true, "toolbox": true, "adobe": true,
+	}
+
+	var updated, failed []string
+	for _, r := range updatable {
+		if cfg.IsPinned(r.App.BundleID) || r.IsMajorUpdate || autoSkipSources[r.Source] {
+			continue
+		}
+		policy := cfg.Policy(r.App.BundleID)
+		if policy == config.PolicyManual || policy == config.PolicyNotifyOnly {
+			continue
+		}
+		updateErr, _ := executeUpdate(ctx, r, runner, bm, inst)
+		if updateErr == nil || errors.Is(updateErr, checker.ErrOpenedExternally) {
+			updated = append(updated, r.App.Name)
+		} else {
+			failed = append(failed, r.App.Name)
+		}
+	}
+
+	if len(updated) > 0 {
+		body := fmt.Sprintf("Updated: %s", strings.Join(updated, ", "))
+		if len(failed) > 0 {
+			body += fmt.Sprintf(". Failed: %s", strings.Join(failed, ", "))
+		}
+		_ = sendNotification(ctx, runner, len(updated), body, "")
+	}
 }
 
 // buildNotificationBody creates the notification body text showing version transitions,

--- a/cmd/updater/notify_test.go
+++ b/cmd/updater/notify_test.go
@@ -203,6 +203,16 @@ func TestSendInteractiveNotification(t *testing.T) {
 	}
 }
 
+func TestRunNotify_AutoUpdateFlag(t *testing.T) {
+	f := notifyCmd.Flags().Lookup("auto-update")
+	if f == nil {
+		t.Fatal("--auto-update flag not registered")
+	}
+	if f.DefValue != "false" {
+		t.Errorf("default = %q, want %q", f.DefValue, "false")
+	}
+}
+
 func TestSendNotification_PassiveDefault(t *testing.T) {
 	captureRunner := &captureNotifyRunner{}
 

--- a/cmd/updater/rollback.go
+++ b/cmd/updater/rollback.go
@@ -1,7 +1,9 @@
 package main
 
 import (
+	"errors"
 	"fmt"
+	"os"
 	"strings"
 
 	"github.com/luzhengda/updater/internal/backup"
@@ -10,20 +12,32 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var flagRollbackAll bool
+
 var rollbackCmd = &cobra.Command{
-	Use:   "rollback <app-name>",
+	Use:   "rollback [app-name]",
 	Short: "Restore an app to its previous version",
-	Args:  cobra.ExactArgs(1),
+	Args:  cobra.MaximumNArgs(1),
 	RunE:  runRollback,
 }
 
 func init() {
+	rollbackCmd.Flags().BoolVar(&flagRollbackAll, "all", false, "rollback all apps with backups")
 	rootCmd.AddCommand(rollbackCmd)
 }
 
 func runRollback(cmd *cobra.Command, args []string) error {
+	if flagRollbackAll {
+		return rollbackAll(cmd)
+	}
+	if len(args) == 0 {
+		return errors.New("app name required (or use --all)")
+	}
+	return rollbackSingle(cmd, args[0])
+}
+
+func rollbackSingle(cmd *cobra.Command, name string) error {
 	ctx := cmd.Context()
-	name := args[0]
 
 	cfg, err := config.Load(config.DefaultPath())
 	if err != nil {
@@ -62,5 +76,71 @@ func runRollback(cmd *cobra.Command, args []string) error {
 	}
 
 	fmt.Fprintf(cmd.OutOrStdout(), "Successfully restored %s to version %s\n", latest.AppName, latest.Version)
+	return nil
+}
+
+func rollbackAll(cmd *cobra.Command) error {
+	ctx := cmd.Context()
+	w := cmd.OutOrStdout()
+
+	baseDir := backup.DefaultBaseDir()
+	entries, err := os.ReadDir(baseDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			fmt.Fprintln(w, "No backups found.")
+			return nil
+		}
+		return fmt.Errorf("failed to read backup directory: %w", err)
+	}
+
+	cfg, err := config.Load(config.DefaultPath())
+	if err != nil {
+		return fmt.Errorf("failed to load config: %w", err)
+	}
+
+	runner := &checker.RealCmdRunner{}
+	bm := backup.NewManager(baseDir, cfg.MaxBackupsOrDefault(), runner)
+
+	// Discover installed apps once for quit-if-running lookups.
+	installedApps, _ := discoverApps()
+
+	var restored, failed int
+
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		dirName := entry.Name()
+
+		backups, err := bm.List(dirName)
+		if err != nil || len(backups) == 0 {
+			continue
+		}
+
+		latest := backups[0]
+		fmt.Fprintf(w, "Restoring %s to version %s...\n", latest.AppName, latest.Version)
+
+		// Quit the app if running.
+		for _, a := range installedApps {
+			if strings.EqualFold(a.Name, latest.AppName) {
+				quitAppIfRunning(ctx, a, runner)
+				break
+			}
+		}
+
+		if err := bm.Restore(ctx, dirName); err != nil {
+			fmt.Fprintf(w, "  Failed to restore %s: %v\n", latest.AppName, err)
+			failed++
+			continue
+		}
+		restored++
+	}
+
+	if restored == 0 && failed == 0 {
+		fmt.Fprintln(w, "No backups found.")
+		return nil
+	}
+
+	fmt.Fprintf(w, "Rolled back %d app(s), %d failed.\n", restored, failed)
 	return nil
 }

--- a/cmd/updater/schedule.go
+++ b/cmd/updater/schedule.go
@@ -41,6 +41,7 @@ const plistTemplate = `<?xml version="1.0" encoding="UTF-8"?>
 	<array>
 		<string>{{.Binary}}</string>
 		<string>notify</string>
+		<string>--auto-update</string>
 	</array>
 	<key>StartInterval</key>
 	<integer>{{.IntervalSeconds}}</integer>

--- a/internal/app/discovery_test.go
+++ b/internal/app/discovery_test.go
@@ -474,13 +474,419 @@ func TestToCaskName(t *testing.T) {
 		{"Firefox", "firefox"},
 		{"Arc Browser", "arc-browser"},
 		{"1Password 7", "1password-7"},
+		{"PDF Expert", "pdf-expert"},
+		{"", ""},
+		{"UPPER CASE", "upper-case"},
+		{"App.Name.With.Dots", "appnamewithdots"},
 	}
 	for _, tt := range tests {
-		t.Run(tt.input, func(t *testing.T) {
+		name := tt.input
+		if name == "" {
+			name = "empty"
+		}
+		t.Run(name, func(t *testing.T) {
 			got := ToCaskName(tt.input)
 			if got != tt.want {
 				t.Errorf("ToCaskName(%q) = %q, want %q", tt.input, got, tt.want)
 			}
 		})
+	}
+}
+
+func TestDiscoverSkipsNonAppEntries(t *testing.T) {
+	dir := t.TempDir()
+
+	// Create a non-.app directory — should be ignored.
+	if err := os.MkdirAll(filepath.Join(dir, "NotAnApp"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create a regular file (not a directory) — should be ignored.
+	if err := os.WriteFile(filepath.Join(dir, "readme.txt"), []byte("hi"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create a regular file with .app suffix — should be ignored (not a directory).
+	if err := os.WriteFile(filepath.Join(dir, "Fake.app"), []byte("not a real app"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	apps, err := Discover(dir)
+	if err != nil {
+		t.Fatalf("Discover failed: %v", err)
+	}
+	if len(apps) != 0 {
+		t.Errorf("expected 0 apps, got %d", len(apps))
+	}
+}
+
+func TestDiscoverSkipsUnparseableApp(t *testing.T) {
+	dir := t.TempDir()
+
+	// Create a .app directory with invalid Info.plist — should be skipped.
+	appDir := filepath.Join(dir, "Broken.app")
+	contentsDir := filepath.Join(appDir, "Contents")
+	if err := os.MkdirAll(contentsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(contentsDir, "Info.plist"), []byte("not valid plist"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Also create a valid app to ensure Discover still returns it.
+	createFakeApp(t, dir, "Valid", plistData{
+		BundleName:         "Valid",
+		BundleID:           "com.example.valid",
+		ShortVersionString: "1.0.0",
+		BundleVersion:      "1",
+	}, false, false)
+
+	apps, err := Discover(dir)
+	if err != nil {
+		t.Fatalf("Discover failed: %v", err)
+	}
+	if len(apps) != 1 {
+		t.Errorf("expected 1 app (broken skipped), got %d", len(apps))
+	}
+	if len(apps) == 1 && apps[0].Name != "Valid" {
+		t.Errorf("expected Valid app, got %s", apps[0].Name)
+	}
+}
+
+func TestDiscoverSymlinkAppToDirectory(t *testing.T) {
+	dir := t.TempDir()
+	targetDir := t.TempDir()
+
+	// Create a real app in the target directory.
+	appPath := createFakeApp(t, targetDir, "Linked", plistData{
+		BundleName:         "Linked",
+		BundleID:           "com.example.linked",
+		ShortVersionString: "1.0.0",
+		BundleVersion:      "1",
+	}, false, false)
+
+	// Create a symlink in the scan directory pointing to the real app.
+	symlinkPath := filepath.Join(dir, "Linked.app")
+	if err := os.Symlink(appPath, symlinkPath); err != nil {
+		t.Fatal(err)
+	}
+
+	apps, err := Discover(dir)
+	if err != nil {
+		t.Fatalf("Discover failed: %v", err)
+	}
+	if len(apps) != 1 {
+		t.Fatalf("expected 1 app via symlink, got %d", len(apps))
+	}
+	if apps[0].BundleID != "com.example.linked" {
+		t.Errorf("expected bundle ID com.example.linked, got %s", apps[0].BundleID)
+	}
+}
+
+func TestDiscoverSymlinkAppToFile(t *testing.T) {
+	dir := t.TempDir()
+
+	// Create a regular file and symlink a .app name to it — should be ignored.
+	targetFile := filepath.Join(dir, "target.txt")
+	if err := os.WriteFile(targetFile, []byte("not a dir"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	symlinkPath := filepath.Join(dir, "FakeLink.app")
+	if err := os.Symlink(targetFile, symlinkPath); err != nil {
+		t.Fatal(err)
+	}
+
+	apps, err := Discover(dir)
+	if err != nil {
+		t.Fatalf("Discover failed: %v", err)
+	}
+	if len(apps) != 0 {
+		t.Errorf("expected 0 apps (symlink to file), got %d", len(apps))
+	}
+}
+
+func TestDiscoverSymlinkAppBroken(t *testing.T) {
+	dir := t.TempDir()
+
+	// Create a dangling symlink (target does not exist).
+	symlinkPath := filepath.Join(dir, "Dangling.app")
+	if err := os.Symlink("/nonexistent/target", symlinkPath); err != nil {
+		t.Fatal(err)
+	}
+
+	apps, err := Discover(dir)
+	if err != nil {
+		t.Fatalf("Discover failed: %v", err)
+	}
+	if len(apps) != 0 {
+		t.Errorf("expected 0 apps (dangling symlink), got %d", len(apps))
+	}
+}
+
+func TestDiscoverUnreadableDirectory(t *testing.T) {
+	dir := t.TempDir()
+	unreadable := filepath.Join(dir, "noperm")
+	if err := os.MkdirAll(unreadable, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// Remove read permission.
+	if err := os.Chmod(unreadable, 0o000); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		os.Chmod(unreadable, 0o755)
+	})
+
+	_, err := Discover(unreadable)
+	if err == nil {
+		t.Fatal("expected error for unreadable directory, got nil")
+	}
+}
+
+func TestClassifySource_SparkleWithoutFeedURL(t *testing.T) {
+	dir := t.TempDir()
+
+	// Create an app with Sparkle framework but no SUFeedURL — should be SourceUnknown.
+	createFakeApp(t, dir, "SparkleNoFeed", plistData{
+		BundleName:         "SparkleNoFeed",
+		BundleID:           "com.example.sparkenofeed",
+		ShortVersionString: "1.0.0",
+		BundleVersion:      "1",
+	}, false, true) // sparkle=true adds the framework
+
+	apps, err := Discover(dir)
+	if err != nil {
+		t.Fatalf("Discover failed: %v", err)
+	}
+	if len(apps) != 1 {
+		t.Fatalf("expected 1 app, got %d", len(apps))
+	}
+	if apps[0].Source != SourceUnknown {
+		t.Errorf("expected source %q (Sparkle framework but no feed URL), got %q", SourceUnknown, apps[0].Source)
+	}
+}
+
+func TestParseApp_BundleNameFallback(t *testing.T) {
+	dir := t.TempDir()
+
+	// Create an app with BundleName set but BundleDisplayName empty.
+	createFakeApp(t, dir, "SomeName", plistData{
+		BundleName:         "ActualBundleName",
+		BundleID:           "com.example.bundlename",
+		ShortVersionString: "1.0.0",
+		BundleVersion:      "1",
+	}, false, false)
+
+	apps, err := Discover(dir)
+	if err != nil {
+		t.Fatalf("Discover failed: %v", err)
+	}
+	if len(apps) != 1 {
+		t.Fatalf("expected 1 app, got %d", len(apps))
+	}
+	if apps[0].Name != "ActualBundleName" {
+		t.Errorf("expected name ActualBundleName (from BundleName), got %s", apps[0].Name)
+	}
+}
+
+func TestIsToolboxPath_BrokenSymlink(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Create a symlink pointing to a nonexistent target — EvalSymlinks will error.
+	brokenLink := filepath.Join(tmpDir, "Broken.app")
+	if err := os.Symlink("/nonexistent/path/app", brokenLink); err != nil {
+		t.Fatal(err)
+	}
+
+	if isToolboxPath(brokenLink) {
+		t.Error("expected isToolboxPath to be false for broken symlink")
+	}
+}
+
+func TestEnrichElectronApp_InvalidYAML(t *testing.T) {
+	dir := t.TempDir()
+
+	appPath := createFakeApp(t, dir, "BadYML", plistData{
+		BundleName:         "BadYML",
+		BundleID:           "com.example.badyml",
+		ShortVersionString: "1.0.0",
+		BundleVersion:      "1",
+	}, false, false)
+
+	// Add Electron Framework.
+	contentsDir := filepath.Join(appPath, "Contents")
+	electronDir := filepath.Join(contentsDir, "Frameworks", "Electron Framework.framework")
+	if err := os.MkdirAll(electronDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Write invalid YAML in app-update.yml.
+	resourceDir := filepath.Join(contentsDir, "Resources")
+	if err := os.MkdirAll(resourceDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(resourceDir, "app-update.yml"), []byte(":\ninvalid:\n  - [\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	apps, err := Discover(dir)
+	if err != nil {
+		t.Fatalf("Discover failed: %v", err)
+	}
+	if len(apps) != 1 {
+		t.Fatalf("expected 1 app, got %d", len(apps))
+	}
+	// Should remain SourceElectron with no enrichment.
+	if apps[0].Source != SourceElectron {
+		t.Errorf("expected source %q, got %q", SourceElectron, apps[0].Source)
+	}
+	if apps[0].GitHubRepo != "" {
+		t.Errorf("expected empty GitHubRepo, got %q", apps[0].GitHubRepo)
+	}
+}
+
+func TestEnrichElectronApp_GenericNonHTTPURL(t *testing.T) {
+	dir := t.TempDir()
+
+	appPath := createFakeApp(t, dir, "FTPElectron", plistData{
+		BundleName:         "FTPElectron",
+		BundleID:           "com.example.ftpelectron",
+		ShortVersionString: "1.0.0",
+		BundleVersion:      "1",
+	}, false, false)
+
+	// Add Electron Framework.
+	contentsDir := filepath.Join(appPath, "Contents")
+	electronDir := filepath.Join(contentsDir, "Frameworks", "Electron Framework.framework")
+	if err := os.MkdirAll(electronDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Write app-update.yml with generic provider and non-http URL.
+	resourceDir := filepath.Join(contentsDir, "Resources")
+	if err := os.MkdirAll(resourceDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	yml := "provider: generic\nurl: ftp://example.com/updates\n"
+	if err := os.WriteFile(filepath.Join(resourceDir, "app-update.yml"), []byte(yml), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	apps, err := Discover(dir)
+	if err != nil {
+		t.Fatalf("Discover failed: %v", err)
+	}
+	if len(apps) != 1 {
+		t.Fatalf("expected 1 app, got %d", len(apps))
+	}
+	if apps[0].ElectronUpdateURL != "" {
+		t.Errorf("expected empty ElectronUpdateURL for non-http URL, got %q", apps[0].ElectronUpdateURL)
+	}
+}
+
+func TestEnrichElectronApp_GitHubMissingOwnerOrRepo(t *testing.T) {
+	dir := t.TempDir()
+
+	appPath := createFakeApp(t, dir, "PartialGH", plistData{
+		BundleName:         "PartialGH",
+		BundleID:           "com.example.partialgh",
+		ShortVersionString: "1.0.0",
+		BundleVersion:      "1",
+	}, false, false)
+
+	// Add Electron Framework.
+	contentsDir := filepath.Join(appPath, "Contents")
+	electronDir := filepath.Join(contentsDir, "Frameworks", "Electron Framework.framework")
+	if err := os.MkdirAll(electronDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Write app-update.yml with GitHub provider but missing repo.
+	resourceDir := filepath.Join(contentsDir, "Resources")
+	if err := os.MkdirAll(resourceDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	yml := "provider: github\nowner: myorg\n"
+	if err := os.WriteFile(filepath.Join(resourceDir, "app-update.yml"), []byte(yml), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	apps, err := Discover(dir)
+	if err != nil {
+		t.Fatalf("Discover failed: %v", err)
+	}
+	if len(apps) != 1 {
+		t.Fatalf("expected 1 app, got %d", len(apps))
+	}
+	// Should stay SourceElectron since repo is missing.
+	if apps[0].Source != SourceElectron {
+		t.Errorf("expected source %q, got %q", SourceElectron, apps[0].Source)
+	}
+	if apps[0].GitHubRepo != "" {
+		t.Errorf("expected empty GitHubRepo, got %q", apps[0].GitHubRepo)
+	}
+}
+
+func TestDiscoverAppWithNoInfoPlist(t *testing.T) {
+	dir := t.TempDir()
+
+	// Create a .app directory with Contents but no Info.plist.
+	appDir := filepath.Join(dir, "NoInfoPlist.app")
+	if err := os.MkdirAll(filepath.Join(appDir, "Contents"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	apps, err := Discover(dir)
+	if err != nil {
+		t.Fatalf("Discover failed: %v", err)
+	}
+	if len(apps) != 0 {
+		t.Errorf("expected 0 apps (no Info.plist), got %d", len(apps))
+	}
+}
+
+func TestEnrichElectronApp_UnknownProvider(t *testing.T) {
+	dir := t.TempDir()
+
+	appPath := createFakeApp(t, dir, "CustomProvider", plistData{
+		BundleName:         "CustomProvider",
+		BundleID:           "com.example.custom",
+		ShortVersionString: "1.0.0",
+		BundleVersion:      "1",
+	}, false, false)
+
+	// Add Electron Framework.
+	contentsDir := filepath.Join(appPath, "Contents")
+	electronDir := filepath.Join(contentsDir, "Frameworks", "Electron Framework.framework")
+	if err := os.MkdirAll(electronDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Write app-update.yml with an unknown provider.
+	resourceDir := filepath.Join(contentsDir, "Resources")
+	if err := os.MkdirAll(resourceDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	yml := "provider: s3\nurl: https://s3.amazonaws.com/myapp\n"
+	if err := os.WriteFile(filepath.Join(resourceDir, "app-update.yml"), []byte(yml), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	apps, err := Discover(dir)
+	if err != nil {
+		t.Fatalf("Discover failed: %v", err)
+	}
+	if len(apps) != 1 {
+		t.Fatalf("expected 1 app, got %d", len(apps))
+	}
+	// Unknown provider: stays SourceElectron, no enrichment.
+	if apps[0].Source != SourceElectron {
+		t.Errorf("expected source %q, got %q", SourceElectron, apps[0].Source)
+	}
+	if apps[0].GitHubRepo != "" {
+		t.Errorf("expected empty GitHubRepo, got %q", apps[0].GitHubRepo)
+	}
+	if apps[0].ElectronUpdateURL != "" {
+		t.Errorf("expected empty ElectronUpdateURL, got %q", apps[0].ElectronUpdateURL)
 	}
 }

--- a/internal/checker/brew_formula_test.go
+++ b/internal/checker/brew_formula_test.go
@@ -8,6 +8,30 @@ import (
 	"github.com/luzhengda/updater/internal/app"
 )
 
+func TestBrewFormulaChecker_Name(t *testing.T) {
+	c := NewBrewFormulaChecker(nil)
+	if got := c.Name(); got != "formula" {
+		t.Errorf("Name() = %q, want %q", got, "formula")
+	}
+}
+
+func TestBrewFormulaChecker_LoadOutdatedJSONParseError(t *testing.T) {
+	runner := &MockCmdRunner{Output: []byte(`not json`)}
+	c := NewBrewFormulaChecker(runner)
+
+	a := &app.App{
+		Name:        "node",
+		Version:     "20.0.0",
+		Source:      app.SourceBrewFormula,
+		FormulaName: "node",
+	}
+
+	_, err := c.Check(context.Background(), a)
+	if err == nil {
+		t.Fatal("expected error for invalid JSON from loadOutdated, got nil")
+	}
+}
+
 func TestBrewFormulaChecker_CanCheck(t *testing.T) {
 	c := NewBrewFormulaChecker(nil)
 

--- a/internal/checker/brew_info_test.go
+++ b/internal/checker/brew_info_test.go
@@ -200,3 +200,14 @@ func TestBrewInfoChecker_Name(t *testing.T) {
 		t.Errorf("Name() = %q, want %q", got, "brew-info")
 	}
 }
+
+func TestBrewInfoChecker_CheckEmptyCaskName(t *testing.T) {
+	runner := &MockCmdRunner{Output: []byte(`{}`)}
+	checker := NewBrewInfoChecker(runner)
+	a := &app.App{Name: "NoName", Version: "1.0.0"}
+
+	_, err := checker.Check(context.Background(), a)
+	if err == nil {
+		t.Fatal("expected error for empty cask name, got nil")
+	}
+}

--- a/internal/checker/brew_test.go
+++ b/internal/checker/brew_test.go
@@ -2,6 +2,7 @@ package checker
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/luzhengda/updater/internal/app"
@@ -158,6 +159,57 @@ func TestBrewChecker_CheckNoUpdate(t *testing.T) {
 
 	if result.HasUpdate {
 		t.Error("expected HasUpdate to be false")
+	}
+}
+
+func TestBrewChecker_Name(t *testing.T) {
+	c := NewBrewChecker(nil)
+	if got := c.Name(); got != "brew" {
+		t.Errorf("Name() = %q, want %q", got, "brew")
+	}
+}
+
+func TestBrewChecker_CheckEmptyCaskName(t *testing.T) {
+	runner := &MockCmdRunner{Output: []byte(`[]`)}
+	c := NewBrewChecker(runner)
+	a := &app.App{Name: "NoName", Version: "1.0.0"}
+
+	_, err := c.Check(context.Background(), a)
+	if err == nil {
+		t.Fatal("expected error for empty cask name, got nil")
+	}
+}
+
+func TestBrewChecker_CheckRunnerError(t *testing.T) {
+	runner := &MockCmdRunner{Err: fmt.Errorf("brew not found")}
+	c := NewBrewChecker(runner)
+	a := &app.App{Name: "Firefox", Version: "1.0.0", CaskName: "firefox", InstalledViaBrew: true}
+
+	_, err := c.Check(context.Background(), a)
+	if err == nil {
+		t.Fatal("expected error when runner fails, got nil")
+	}
+}
+
+func TestBrewChecker_ParseOutdatedInvalidJSON(t *testing.T) {
+	// Neither flat array nor wrapped format — should error
+	_, err := parseBrewOutdated([]byte(`{"unexpected":"format"}`))
+	if err != nil {
+		// The wrapped format with no casks/formulae returns empty successfully.
+		// That's fine — but truly invalid JSON should fail.
+	}
+
+	_, err = parseBrewOutdated([]byte(`not json at all`))
+	if err == nil {
+		t.Fatal("expected error for invalid JSON, got nil")
+	}
+}
+
+func TestListInstalledCasks_RunnerError(t *testing.T) {
+	runner := &MockCmdRunner{Err: fmt.Errorf("brew not installed")}
+	_, err := ListInstalledCasks(context.Background(), runner)
+	if err == nil {
+		t.Fatal("expected error when runner fails, got nil")
 	}
 }
 

--- a/internal/checker/github_test.go
+++ b/internal/checker/github_test.go
@@ -9,6 +9,76 @@ import (
 	"github.com/luzhengda/updater/internal/app"
 )
 
+func TestGitHubChecker_Name(t *testing.T) {
+	c := NewGitHubChecker(nil, "", "")
+	if got := c.Name(); got != "github" {
+		t.Errorf("Name() = %q, want %q", got, "github")
+	}
+}
+
+func TestGitHubChecker_CheckErrorPaths(t *testing.T) {
+	t.Run("empty GitHub repo", func(t *testing.T) {
+		c := NewGitHubChecker(nil, "", "")
+		a := &app.App{Name: "TestApp", Version: "1.0.0"}
+
+		_, err := c.Check(context.Background(), a)
+		if err == nil {
+			t.Fatal("expected error for empty GitHubRepo, got nil")
+		}
+	})
+
+	t.Run("server gone (connection refused)", func(t *testing.T) {
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+		baseURL := ts.URL
+		ts.Close()
+
+		c := NewGitHubChecker(ts.Client(), baseURL, "")
+		a := &app.App{Name: "TestApp", Version: "1.0.0", GitHubRepo: "test/app"}
+
+		_, err := c.Check(context.Background(), a)
+		if err == nil {
+			t.Fatal("expected error when server is gone, got nil")
+		}
+	})
+
+	t.Run("non-200 status code", func(t *testing.T) {
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusForbidden)
+		}))
+		defer ts.Close()
+
+		c := NewGitHubChecker(ts.Client(), ts.URL, "")
+		a := &app.App{Name: "TestApp", Version: "1.0.0", GitHubRepo: "test/app"}
+
+		_, err := c.Check(context.Background(), a)
+		if err == nil {
+			t.Fatal("expected error for non-200 status, got nil")
+		}
+	})
+
+	t.Run("invalid JSON response", func(t *testing.T) {
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.Write([]byte("not json"))
+		}))
+		defer ts.Close()
+
+		c := NewGitHubChecker(ts.Client(), ts.URL, "")
+		a := &app.App{Name: "TestApp", Version: "1.0.0", GitHubRepo: "test/app"}
+
+		_, err := c.Check(context.Background(), a)
+		if err == nil {
+			t.Fatal("expected error for invalid JSON, got nil")
+		}
+	})
+}
+
+func TestHasMacKeyword_OSX(t *testing.T) {
+	if !hasMacKeyword("app-osx-arm64.dmg") {
+		t.Error("expected hasMacKeyword to return true for 'osx' keyword")
+	}
+}
+
 const testReleaseJSON = `{
   "tag_name": "v2.0.0",
   "name": "Release 2.0.0",

--- a/internal/checker/integration_test.go
+++ b/internal/checker/integration_test.go
@@ -3,12 +3,96 @@ package checker
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/luzhengda/updater/internal/app"
 )
+
+func TestRealCmdRunner_Run(t *testing.T) {
+	r := &RealCmdRunner{}
+	output, err := r.Run(context.Background(), "echo", "hello")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	got := strings.TrimSpace(string(output))
+	if got != "hello" {
+		t.Errorf("output = %q, want %q", got, "hello")
+	}
+}
+
+func TestRealCmdRunner_RunError(t *testing.T) {
+	r := &RealCmdRunner{}
+	_, err := r.Run(context.Background(), "nonexistent-command-12345")
+	if err == nil {
+		t.Fatal("expected error for nonexistent command, got nil")
+	}
+}
+
+func TestMultiMockCmdRunner_Run(t *testing.T) {
+	runner := &MultiMockCmdRunner{
+		Responses: map[string]MockResponse{
+			"brew outdated --cask --greedy --json": {
+				Output: []byte(`[{"name":"firefox","current_version":"2.0"}]`),
+			},
+			"mas outdated": {
+				Output: []byte("441258766 Magnet (3.0.6 -> 3.0.7)\n"),
+			},
+			"failing-cmd": {
+				Err: fmt.Errorf("command failed"),
+			},
+		},
+	}
+
+	t.Run("matching key with args", func(t *testing.T) {
+		output, err := runner.Run(context.Background(), "brew", "outdated", "--cask", "--greedy", "--json")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !strings.Contains(string(output), "firefox") {
+			t.Errorf("expected output to contain 'firefox', got %q", string(output))
+		}
+	})
+
+	t.Run("matching key without extra args", func(t *testing.T) {
+		output, err := runner.Run(context.Background(), "mas", "outdated")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !strings.Contains(string(output), "Magnet") {
+			t.Errorf("expected output to contain 'Magnet', got %q", string(output))
+		}
+	})
+
+	t.Run("matching key with error", func(t *testing.T) {
+		_, err := runner.Run(context.Background(), "failing-cmd")
+		if err == nil {
+			t.Fatal("expected error for failing command, got nil")
+		}
+	})
+
+	t.Run("no match falls back to nil", func(t *testing.T) {
+		output, err := runner.Run(context.Background(), "unknown-command", "arg1")
+		if err != nil {
+			t.Fatalf("expected nil error for unmatched key, got %v", err)
+		}
+		if output != nil {
+			t.Errorf("expected nil output for unmatched key, got %q", string(output))
+		}
+	})
+
+	t.Run("command with no args", func(t *testing.T) {
+		// Test that a key with just the name (no args) works.
+		output, err := runner.Run(context.Background(), "failing-cmd")
+		if err == nil {
+			t.Fatal("expected error")
+		}
+		_ = output
+	})
+}
 
 func TestSparkle_EndToEnd(t *testing.T) {
 	var serverURL string

--- a/internal/checker/mas_test.go
+++ b/internal/checker/mas_test.go
@@ -2,10 +2,29 @@ package checker
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/luzhengda/updater/internal/app"
 )
+
+func TestMASChecker_Name(t *testing.T) {
+	c := NewMASChecker(nil)
+	if got := c.Name(); got != "mas" {
+		t.Errorf("Name() = %q, want %q", got, "mas")
+	}
+}
+
+func TestMASChecker_CheckRunnerError(t *testing.T) {
+	runner := &MockCmdRunner{Err: fmt.Errorf("mas not found")}
+	c := NewMASChecker(runner)
+	a := &app.App{Name: "Magnet", Version: "3.0.6", Source: app.SourceMAS, MASID: "441258766"}
+
+	_, err := c.Check(context.Background(), a)
+	if err == nil {
+		t.Fatal("expected error when runner fails, got nil")
+	}
+}
 
 func TestMASChecker_ParseOutdated(t *testing.T) {
 	output := "441258766 Magnet (3.0.6 -> 3.0.7)\n1176895641 Spark (3.27.8 -> 3.27.9)\n"

--- a/internal/checker/sparkle_test.go
+++ b/internal/checker/sparkle_test.go
@@ -9,6 +9,166 @@ import (
 	"github.com/luzhengda/updater/internal/app"
 )
 
+func TestSparkleChecker_Name(t *testing.T) {
+	c := NewSparkleChecker(nil)
+	if got := c.Name(); got != "sparkle" {
+		t.Errorf("Name() = %q, want %q", got, "sparkle")
+	}
+}
+
+func TestSparkleChecker_CheckErrorPaths(t *testing.T) {
+	t.Run("empty feed URL", func(t *testing.T) {
+		c := NewSparkleChecker(nil)
+		a := &app.App{Name: "TestApp", Version: "1.0.0"}
+
+		_, err := c.Check(context.Background(), a)
+		if err == nil {
+			t.Fatal("expected error for empty feed URL, got nil")
+		}
+	})
+
+	t.Run("invalid feed URL", func(t *testing.T) {
+		c := NewSparkleChecker(nil)
+		a := &app.App{Name: "TestApp", Version: "1.0.0", FeedURL: "://bad-url"}
+
+		_, err := c.Check(context.Background(), a)
+		if err == nil {
+			t.Fatal("expected error for invalid feed URL, got nil")
+		}
+	})
+
+	t.Run("server gone (connection refused)", func(t *testing.T) {
+		// Create a server, get its URL, then close it immediately.
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+		feedURL := ts.URL
+		ts.Close()
+
+		c := NewSparkleChecker(ts.Client())
+		a := &app.App{Name: "TestApp", Version: "1.0.0", FeedURL: feedURL}
+
+		_, err := c.Check(context.Background(), a)
+		if err == nil {
+			t.Fatal("expected error when server is gone, got nil")
+		}
+	})
+
+	t.Run("non-200 status code", func(t *testing.T) {
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusNotFound)
+		}))
+		defer ts.Close()
+
+		c := NewSparkleChecker(ts.Client())
+		a := &app.App{Name: "TestApp", Version: "1.0.0", FeedURL: ts.URL}
+
+		_, err := c.Check(context.Background(), a)
+		if err == nil {
+			t.Fatal("expected error for non-200 status, got nil")
+		}
+	})
+
+	t.Run("invalid XML body", func(t *testing.T) {
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Write([]byte("this is not XML"))
+		}))
+		defer ts.Close()
+
+		c := NewSparkleChecker(ts.Client())
+		a := &app.App{Name: "TestApp", Version: "1.0.0", FeedURL: ts.URL}
+
+		_, err := c.Check(context.Background(), a)
+		if err == nil {
+			t.Fatal("expected error for invalid XML, got nil")
+		}
+	})
+
+	t.Run("empty items in feed", func(t *testing.T) {
+		emptyXML := `<?xml version="1.0" encoding="utf-8"?>
+<rss version="2.0" xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle">
+  <channel>
+    <title>Empty Feed</title>
+  </channel>
+</rss>`
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Write([]byte(emptyXML))
+		}))
+		defer ts.Close()
+
+		c := NewSparkleChecker(ts.Client())
+		a := &app.App{Name: "TestApp", Version: "1.0.0", FeedURL: ts.URL}
+
+		_, err := c.Check(context.Background(), a)
+		if err == nil {
+			t.Fatal("expected error for empty feed items, got nil")
+		}
+	})
+}
+
+func TestFindBestItem_AllFilteredOut(t *testing.T) {
+	// All items are filtered out by OS version, should return items[0] as fallback.
+	orig := getMacOSVersionFn
+	getMacOSVersionFn = func() string { return "13.0" }
+	defer func() { getMacOSVersionFn = orig }()
+
+	items := []sparkleItem{
+		{
+			Title:            "Version 4.0",
+			MinSystemVersion: "16.0",
+			Enclosure: sparkleEnclosure{
+				ShortVersionString: "4.0.0",
+				URL:                "https://example.com/v4.dmg",
+			},
+		},
+		{
+			Title:            "Version 3.0",
+			MinSystemVersion: "15.0",
+			Enclosure: sparkleEnclosure{
+				ShortVersionString: "3.0.0",
+				URL:                "https://example.com/v3.dmg",
+			},
+		},
+	}
+
+	result := findBestItem(items, getMacOSVersionFn())
+	// Both items require macOS 15+ or 16+, but we're on 13.0 — all filtered out.
+	// Should fallback to items[0].
+	if result.Enclosure.ShortVersionString != "4.0.0" {
+		t.Errorf("expected fallback to items[0] (4.0.0), got %q", result.Enclosure.ShortVersionString)
+	}
+}
+
+func TestFindBestItem_MaxSystemVersionFilters(t *testing.T) {
+	// Item with maxSystemVersion lower than current OS should be filtered out.
+	orig := getMacOSVersionFn
+	getMacOSVersionFn = func() string { return "16.0" }
+	defer func() { getMacOSVersionFn = orig }()
+
+	items := []sparkleItem{
+		{
+			Title:            "Version 2.0 (old macOS only)",
+			MaxSystemVersion: "14.99",
+			Enclosure: sparkleEnclosure{
+				ShortVersionString: "2.0.0",
+				URL:                "https://example.com/v2.dmg",
+			},
+		},
+		{
+			Title: "Version 3.0 (universal)",
+			Enclosure: sparkleEnclosure{
+				ShortVersionString: "3.0.0",
+				URL:                "https://example.com/v3.dmg",
+			},
+		},
+	}
+
+	result := findBestItem(items, getMacOSVersionFn())
+	// Item 1 (v2.0) has maxSystemVersion=14.99, we're on 16.0, so it should be skipped.
+	// Item 2 (v3.0) has no restrictions, should be selected.
+	if result.Enclosure.ShortVersionString != "3.0.0" {
+		t.Errorf("expected v3.0.0 (maxSystemVersion filtered v2.0.0), got %q", result.Enclosure.ShortVersionString)
+	}
+}
+
 const testAppcastXML = `<?xml version="1.0" encoding="utf-8"?>
 <rss version="2.0" xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle">
   <channel>

--- a/internal/checker/system_test.go
+++ b/internal/checker/system_test.go
@@ -2,10 +2,29 @@ package checker
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/luzhengda/updater/internal/app"
 )
+
+func TestSystemChecker_Name(t *testing.T) {
+	c := NewSystemChecker(nil)
+	if got := c.Name(); got != "system" {
+		t.Errorf("Name() = %q, want %q", got, "system")
+	}
+}
+
+func TestSystemChecker_CheckRunnerError(t *testing.T) {
+	runner := &MockCmdRunner{Err: fmt.Errorf("softwareupdate not found")}
+	c := NewSystemChecker(runner)
+	a := &app.App{Name: "macOS", BundleID: "com.apple.macOS", Version: "15.2"}
+
+	_, err := c.Check(context.Background(), a)
+	if err == nil {
+		t.Fatal("expected error when runner fails, got nil")
+	}
+}
 
 func TestSystemChecker_CanCheck(t *testing.T) {
 	c := NewSystemChecker(nil)

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -524,6 +524,87 @@ func TestPolicy_DefaultEmpty(t *testing.T) {
 	}
 }
 
+func TestLoadConfig_ReadError(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.yaml")
+
+	// Create a valid file, then make it unreadable.
+	if err := os.WriteFile(cfgPath, []byte("ignored_apps: []"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(cfgPath, 0o000); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { os.Chmod(cfgPath, 0o644) })
+
+	_, err := Load(cfgPath)
+	if err == nil {
+		t.Fatal("expected error for unreadable file, got nil")
+	}
+	if !strings.Contains(err.Error(), "failed to read config file") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestLoadConfig_InvalidYAML(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.yaml")
+
+	if err := os.WriteFile(cfgPath, []byte(":::invalid yaml{{["), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := Load(cfgPath)
+	if err == nil {
+		t.Fatal("expected error for invalid YAML, got nil")
+	}
+	if !strings.Contains(err.Error(), "failed to parse config file") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestIsIgnored_NilSet(t *testing.T) {
+	cfg := &Config{} // no buildIgnoredSet called, ignoredSet is nil
+	if cfg.IsIgnored("com.example.app") {
+		t.Error("expected IsIgnored to return false when ignoredSet is nil")
+	}
+}
+
+func TestIsPinned_NilSet(t *testing.T) {
+	cfg := &Config{} // no buildPinnedSet called, pinnedSet is nil
+	if cfg.IsPinned("com.example.app") {
+		t.Error("expected IsPinned to return false when pinnedSet is nil")
+	}
+}
+
+func TestPin_NilPinnedSet(t *testing.T) {
+	cfg := &Config{} // pinnedSet is nil
+	cfg.Pin("com.example.app")
+	if !cfg.IsPinned("com.example.app") {
+		t.Error("expected com.example.app to be pinned after Pin on nil pinnedSet")
+	}
+	if len(cfg.PinnedApps) != 1 || cfg.PinnedApps[0] != "com.example.app" {
+		t.Errorf("PinnedApps = %v, want [com.example.app]", cfg.PinnedApps)
+	}
+}
+
+func TestMerge_MaxBackupsOverride(t *testing.T) {
+	current := &Config{
+		MaxBackups: 2,
+	}
+	current.buildIgnoredSet()
+	current.buildPinnedSet()
+
+	imported := &Config{
+		MaxBackups: 10, // non-zero → should override
+	}
+
+	result := Merge(current, imported)
+	if result.MaxBackups != 10 {
+		t.Errorf("MaxBackups = %d, want 10 (imported should override)", result.MaxBackups)
+	}
+}
+
 func TestMerge_Policies(t *testing.T) {
 	current := &Config{
 		Policies: map[string]string{

--- a/internal/history/history_test.go
+++ b/internal/history/history_test.go
@@ -1,6 +1,7 @@
 package history
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -103,6 +104,152 @@ func TestList_Corrupt(t *testing.T) {
 	_, err := List(path)
 	if err == nil {
 		t.Fatal("expected error for corrupt JSON")
+	}
+}
+
+func TestAppend_ReadOnlyDir(t *testing.T) {
+	dir := t.TempDir()
+	roDir := filepath.Join(dir, "readonly")
+	if err := os.MkdirAll(roDir, 0o555); err != nil {
+		t.Fatal(err)
+	}
+
+	path := filepath.Join(roDir, "subdir", "history.json")
+	entry := Entry{
+		AppName:   "Test",
+		Timestamp: time.Now(),
+	}
+
+	err := Append(path, entry)
+	if err == nil {
+		t.Fatal("expected error when parent dir is read-only")
+	}
+}
+
+func TestAppend_MultipleEntries(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "history.json")
+
+	for i := 0; i < 5; i++ {
+		entry := Entry{
+			AppName:     fmt.Sprintf("App%d", i),
+			FromVersion: fmt.Sprintf("%d.0", i),
+			ToVersion:   fmt.Sprintf("%d.1", i),
+			Source:      "brew",
+			Timestamp:   time.Now(),
+			Success:     true,
+		}
+		if err := Append(path, entry); err != nil {
+			t.Fatalf("Append #%d failed: %v", i, err)
+		}
+	}
+
+	entries, err := List(path)
+	if err != nil {
+		t.Fatalf("List failed: %v", err)
+	}
+	if len(entries) != 5 {
+		t.Fatalf("expected 5 entries, got %d", len(entries))
+	}
+	for i, e := range entries {
+		want := fmt.Sprintf("App%d", i)
+		if e.AppName != want {
+			t.Errorf("entry[%d].AppName = %q, want %q", i, e.AppName, want)
+		}
+	}
+}
+
+func TestAppend_RolledBackField(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "history.json")
+
+	entry := Entry{
+		AppName:     "Firefox",
+		BundleID:    "org.mozilla.firefox",
+		FromVersion: "121.0",
+		ToVersion:   "120.0",
+		Source:      "sparkle",
+		Timestamp:   time.Now(),
+		Success:     false,
+		RolledBack:  true,
+	}
+
+	if err := Append(path, entry); err != nil {
+		t.Fatalf("Append failed: %v", err)
+	}
+
+	entries, err := List(path)
+	if err != nil {
+		t.Fatalf("List failed: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(entries))
+	}
+	if !entries[0].RolledBack {
+		t.Error("expected RolledBack = true, got false")
+	}
+	if entries[0].Success {
+		t.Error("expected Success = false, got true")
+	}
+}
+
+func TestList_EmptyArray(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "history.json")
+	if err := os.WriteFile(path, []byte("[]"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	entries, err := List(path)
+	if err != nil {
+		t.Fatalf("List failed: %v", err)
+	}
+	if entries == nil {
+		t.Fatal("expected non-nil empty slice, got nil")
+	}
+	if len(entries) != 0 {
+		t.Errorf("expected 0 entries, got %d", len(entries))
+	}
+}
+
+func TestList_ReadError(t *testing.T) {
+	dir := t.TempDir()
+	// Pass a directory path instead of a file — os.ReadFile will fail.
+	_, err := List(dir)
+	if err == nil {
+		t.Fatal("expected error when path is a directory")
+	}
+}
+
+func TestAppend_CorruptExistingFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "history.json")
+	// Write corrupt JSON so that List (called inside Append) fails.
+	if err := os.WriteFile(path, []byte("{bad json"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	entry := Entry{AppName: "Test", Timestamp: time.Now()}
+	err := Append(path, entry)
+	if err == nil {
+		t.Fatal("expected error when existing file has corrupt JSON")
+	}
+}
+
+func TestAppend_WriteError(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "history.json")
+
+	// Make the directory read-only so MkdirAll succeeds (dir exists)
+	// but WriteFile fails (no write permission).
+	if err := os.Chmod(dir, 0o555); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		// Restore permissions so t.TempDir() cleanup succeeds.
+		os.Chmod(dir, 0o755)
+	})
+
+	entry := Entry{AppName: "Test", Timestamp: time.Now()}
+	err := Append(target, entry)
+	if err == nil {
+		t.Fatal("expected error when directory is not writable")
 	}
 }
 

--- a/internal/updater/updater_test.go
+++ b/internal/updater/updater_test.go
@@ -1,0 +1,991 @@
+package updater
+
+import (
+	"context"
+	"fmt"
+	"runtime"
+	"testing"
+
+	"github.com/luzhengda/updater/internal/app"
+	"github.com/luzhengda/updater/internal/checker"
+	"github.com/luzhengda/updater/internal/config"
+)
+
+// mockChecker implements checker.Checker for testing.
+type mockChecker struct {
+	name     string
+	canCheck func(*app.App) bool
+	result   *checker.UpdateResult
+	err      error
+}
+
+func (m *mockChecker) Name() string                { return m.name }
+func (m *mockChecker) CanCheck(a *app.App) bool     { return m.canCheck(a) }
+func (m *mockChecker) Check(_ context.Context, a *app.App) (*checker.UpdateResult, error) {
+	return m.result, m.err
+}
+
+// --- DiscoverBrewFormulae ---
+
+func TestDiscoverBrewFormulae(t *testing.T) {
+	tests := []struct {
+		name       string
+		output     []byte
+		err        error
+		wantCount  int
+		wantNames  []string
+		wantErr    bool
+	}{
+		{
+			name:      "two formulae sorted alphabetically",
+			output:    []byte("node 22.12.0\npython@3.12 3.12.8\n"),
+			wantCount: 2,
+			wantNames: []string{"node", "python@3.12"},
+		},
+		{
+			name:      "single formula",
+			output:    []byte("git 2.43.0\n"),
+			wantCount: 1,
+			wantNames: []string{"git"},
+		},
+		{
+			name:      "empty output",
+			output:    []byte(""),
+			wantCount: 0,
+		},
+		{
+			name:    "runner error",
+			err:     fmt.Errorf("brew not installed"),
+			wantErr: true,
+		},
+		{
+			name:      "multiple versions per formula takes last",
+			output:    []byte("node 20.0.0 22.12.0\n"),
+			wantCount: 1,
+			wantNames: []string{"node"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			runner := &checker.MockCmdRunner{Output: tt.output, Err: tt.err}
+			apps, err := DiscoverBrewFormulae(context.Background(), runner)
+
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if len(apps) != tt.wantCount {
+				t.Fatalf("got %d apps, want %d", len(apps), tt.wantCount)
+			}
+
+			for i, wantName := range tt.wantNames {
+				a := apps[i]
+				if a.Name != wantName {
+					t.Errorf("app[%d].Name = %q, want %q", i, a.Name, wantName)
+				}
+				if a.BundleID != "homebrew.formula."+wantName {
+					t.Errorf("app[%d].BundleID = %q, want %q", i, a.BundleID, "homebrew.formula."+wantName)
+				}
+				if a.Source != app.SourceBrewFormula {
+					t.Errorf("app[%d].Source = %q, want %q", i, a.Source, app.SourceBrewFormula)
+				}
+				if a.FormulaName != wantName {
+					t.Errorf("app[%d].FormulaName = %q, want %q", i, a.FormulaName, wantName)
+				}
+				if !a.InstalledViaBrew {
+					t.Errorf("app[%d].InstalledViaBrew = false, want true", i)
+				}
+			}
+		})
+	}
+}
+
+func TestDiscoverBrewFormulae_VersionCorrectness(t *testing.T) {
+	runner := &checker.MockCmdRunner{
+		Output: []byte("node 20.0.0 22.12.0\npython@3.12 3.12.8\n"),
+	}
+	apps, err := DiscoverBrewFormulae(context.Background(), runner)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(apps) != 2 {
+		t.Fatalf("got %d apps, want 2", len(apps))
+	}
+	// node should take last version "22.12.0"
+	if apps[0].Version != "22.12.0" {
+		t.Errorf("node version = %q, want %q", apps[0].Version, "22.12.0")
+	}
+	if apps[1].Version != "3.12.8" {
+		t.Errorf("python version = %q, want %q", apps[1].Version, "3.12.8")
+	}
+}
+
+// --- EnrichApps ---
+
+func TestEnrichApps_Phase1_GitHubMapping(t *testing.T) {
+	cfg := &config.Config{
+		GitHubMappings: map[string]string{
+			"com.test.app": "owner/repo",
+		},
+	}
+	apps := []*app.App{
+		{Name: "TestApp", BundleID: "com.test.app", Source: app.SourceUnknown},
+		{Name: "OtherApp", BundleID: "com.other.app", Source: app.SourceSparkle},
+	}
+	runner := &checker.MultiMockCmdRunner{
+		Responses: map[string]checker.MockResponse{
+			"brew list --cask": {Output: []byte("")},
+		},
+	}
+
+	result, err := EnrichApps(context.Background(), apps, cfg, runner)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// App with config mapping should get GitHubRepo set and source changed.
+	if result[0].GitHubRepo != "owner/repo" {
+		t.Errorf("GitHubRepo = %q, want %q", result[0].GitHubRepo, "owner/repo")
+	}
+	if result[0].Source != app.SourceGitHub {
+		t.Errorf("Source = %q, want %q", result[0].Source, app.SourceGitHub)
+	}
+
+	// App without mapping should be unchanged.
+	if result[1].GitHubRepo != "" {
+		t.Errorf("OtherApp.GitHubRepo = %q, want empty", result[1].GitHubRepo)
+	}
+}
+
+func TestEnrichApps_Phase1_GitHubMapping_NonUnknownSource(t *testing.T) {
+	cfg := &config.Config{
+		GitHubMappings: map[string]string{
+			"com.sparkle.app": "owner/sparkle-repo",
+		},
+	}
+	apps := []*app.App{
+		{Name: "SparkleApp", BundleID: "com.sparkle.app", Source: app.SourceSparkle},
+	}
+	runner := &checker.MultiMockCmdRunner{
+		Responses: map[string]checker.MockResponse{
+			"brew list --cask": {Output: []byte("")},
+		},
+	}
+
+	result, err := EnrichApps(context.Background(), apps, cfg, runner)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// GitHubRepo should be set but source should NOT change from sparkle.
+	if result[0].GitHubRepo != "owner/sparkle-repo" {
+		t.Errorf("GitHubRepo = %q, want %q", result[0].GitHubRepo, "owner/sparkle-repo")
+	}
+	if result[0].Source != app.SourceSparkle {
+		t.Errorf("Source = %q, want %q (should not change)", result[0].Source, app.SourceSparkle)
+	}
+}
+
+func TestEnrichApps_Phase2_CaskMapping(t *testing.T) {
+	cfg := &config.Config{
+		CaskMappings: map[string]string{
+			"com.test.app2": "test-cask",
+		},
+	}
+	apps := []*app.App{
+		{Name: "TestApp2", BundleID: "com.test.app2", Source: app.SourceUnknown},
+	}
+	runner := &checker.MultiMockCmdRunner{
+		Responses: map[string]checker.MockResponse{
+			"brew list --cask": {Output: []byte("test-cask\n")},
+		},
+	}
+
+	result, err := EnrichApps(context.Background(), apps, cfg, runner)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if result[0].CaskName != "test-cask" {
+		t.Errorf("CaskName = %q, want %q", result[0].CaskName, "test-cask")
+	}
+	// Since cask is in installed list, InstalledViaBrew should be true.
+	if !result[0].InstalledViaBrew {
+		t.Error("InstalledViaBrew = false, want true")
+	}
+	if result[0].Source != app.SourceBrew {
+		t.Errorf("Source = %q, want %q", result[0].Source, app.SourceBrew)
+	}
+}
+
+func TestEnrichApps_Phase3_HeuristicCask(t *testing.T) {
+	cfg := &config.Config{}
+	apps := []*app.App{
+		{Name: "Firefox", BundleID: "org.mozilla.firefox", Source: app.SourceUnknown},
+	}
+	runner := &checker.MultiMockCmdRunner{
+		Responses: map[string]checker.MockResponse{
+			"brew list --cask": {Output: []byte("firefox\ngoogle-chrome\n")},
+		},
+	}
+
+	result, err := EnrichApps(context.Background(), apps, cfg, runner)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// ToCaskName("Firefox") = "firefox", which is in the installed cask list.
+	if result[0].CaskName != "firefox" {
+		t.Errorf("CaskName = %q, want %q", result[0].CaskName, "firefox")
+	}
+	if !result[0].InstalledViaBrew {
+		t.Error("InstalledViaBrew = false, want true")
+	}
+	if result[0].Source != app.SourceBrew {
+		t.Errorf("Source = %q, want %q", result[0].Source, app.SourceBrew)
+	}
+}
+
+func TestEnrichApps_Phase3_ElectronFallback(t *testing.T) {
+	cfg := &config.Config{}
+	apps := []*app.App{
+		{Name: "My Electron App", BundleID: "com.electron.app", Source: app.SourceElectron},
+	}
+	runner := &checker.MultiMockCmdRunner{
+		Responses: map[string]checker.MockResponse{
+			"brew list --cask": {Output: []byte("my-electron-app\n")},
+		},
+	}
+
+	result, err := EnrichApps(context.Background(), apps, cfg, runner)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Electron app with no update URL or GitHub repo should get heuristic cask name.
+	if result[0].CaskName != "my-electron-app" {
+		t.Errorf("CaskName = %q, want %q", result[0].CaskName, "my-electron-app")
+	}
+	if !result[0].InstalledViaBrew {
+		t.Error("InstalledViaBrew = false, want true")
+	}
+	// Source should remain SourceElectron (only SourceUnknown changes to SourceBrew).
+	if result[0].Source != app.SourceElectron {
+		t.Errorf("Source = %q, want %q", result[0].Source, app.SourceElectron)
+	}
+}
+
+func TestEnrichApps_Phase3_ElectronWithUpdateURL_NoFallback(t *testing.T) {
+	cfg := &config.Config{}
+	apps := []*app.App{
+		{
+			Name:              "Electron With URL",
+			BundleID:          "com.electron.withurl",
+			Source:            app.SourceElectron,
+			ElectronUpdateURL: "https://update.example.com",
+		},
+	}
+	runner := &checker.MultiMockCmdRunner{
+		Responses: map[string]checker.MockResponse{
+			"brew list --cask": {Output: []byte("electron-with-url\n")},
+		},
+	}
+
+	result, err := EnrichApps(context.Background(), apps, cfg, runner)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Electron app with update URL should NOT get cask fallback.
+	if result[0].CaskName != "" {
+		t.Errorf("CaskName = %q, want empty (electron with URL should not get fallback)", result[0].CaskName)
+	}
+}
+
+func TestEnrichApps_Phase4_CaskProbe_NotFound(t *testing.T) {
+	cfg := &config.Config{}
+	apps := []*app.App{
+		{Name: "Unknown App", BundleID: "com.unknown.app", Source: app.SourceUnknown},
+	}
+	runner := &checker.MultiMockCmdRunner{
+		Responses: map[string]checker.MockResponse{
+			"brew list --cask": {Output: []byte("")}, // not in installed casks
+			"brew info --cask --json=v2 unknown-app": {Err: fmt.Errorf("exit 1")},
+		},
+	}
+
+	result, err := EnrichApps(context.Background(), apps, cfg, runner)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// CaskExists returns false → CaskName should be cleared.
+	if result[0].CaskName != "" {
+		t.Errorf("CaskName = %q, want empty (cask probe failed)", result[0].CaskName)
+	}
+}
+
+func TestEnrichApps_Phase4_CaskProbe_Found(t *testing.T) {
+	cfg := &config.Config{}
+	apps := []*app.App{
+		{Name: "Discoverable App", BundleID: "com.discoverable.app", Source: app.SourceUnknown},
+	}
+	runner := &checker.MultiMockCmdRunner{
+		Responses: map[string]checker.MockResponse{
+			"brew list --cask": {Output: []byte("")}, // not installed
+			"brew info --cask --json=v2 discoverable-app": {Output: []byte(`{"casks":[{"token":"discoverable-app"}]}`)},
+		},
+	}
+
+	result, err := EnrichApps(context.Background(), apps, cfg, runner)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// CaskExists returns true → CaskName should remain.
+	if result[0].CaskName != "discoverable-app" {
+		t.Errorf("CaskName = %q, want %q", result[0].CaskName, "discoverable-app")
+	}
+}
+
+func TestEnrichApps_Phase4_ConfigCaskMapping_SkipsProbe(t *testing.T) {
+	cfg := &config.Config{
+		CaskMappings: map[string]string{
+			"com.mapped.app": "custom-cask",
+		},
+	}
+	apps := []*app.App{
+		{Name: "Mapped App", BundleID: "com.mapped.app", Source: app.SourceUnknown},
+	}
+	runner := &checker.MultiMockCmdRunner{
+		Responses: map[string]checker.MockResponse{
+			"brew list --cask": {Output: []byte("")},
+			// No brew info response — probe should be skipped.
+		},
+	}
+
+	result, err := EnrichApps(context.Background(), apps, cfg, runner)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Config-mapped cask should be preserved even without probe.
+	if result[0].CaskName != "custom-cask" {
+		t.Errorf("CaskName = %q, want %q", result[0].CaskName, "custom-cask")
+	}
+}
+
+func TestEnrichApps_BrewListError(t *testing.T) {
+	cfg := &config.Config{}
+	apps := []*app.App{
+		{Name: "TestApp", BundleID: "com.test.app", Source: app.SourceUnknown},
+	}
+	runner := &checker.MultiMockCmdRunner{
+		Responses: map[string]checker.MockResponse{
+			"brew list --cask": {Err: fmt.Errorf("brew not installed")},
+		},
+	}
+
+	result, err := EnrichApps(context.Background(), apps, cfg, runner)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Non-fatal: apps returned unchanged.
+	if len(result) != 1 {
+		t.Fatalf("got %d apps, want 1", len(result))
+	}
+	if result[0].CaskName != "" {
+		t.Errorf("CaskName = %q, want empty (brew not available)", result[0].CaskName)
+	}
+}
+
+func TestEnrichApps_Phase4_ElectronProbe(t *testing.T) {
+	cfg := &config.Config{}
+	apps := []*app.App{
+		{
+			Name:     "Electron No Meta",
+			BundleID: "com.electron.nometa",
+			Source:   app.SourceElectron,
+			// No ElectronUpdateURL, no GitHubRepo
+		},
+	}
+	runner := &checker.MultiMockCmdRunner{
+		Responses: map[string]checker.MockResponse{
+			"brew list --cask": {Output: []byte("")}, // not installed
+			"brew info --cask --json=v2 electron-no-meta": {Err: fmt.Errorf("not found")},
+		},
+	}
+
+	result, err := EnrichApps(context.Background(), apps, cfg, runner)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Electron app without meta that fails probe → CaskName cleared.
+	if result[0].CaskName != "" {
+		t.Errorf("CaskName = %q, want empty (probe failed)", result[0].CaskName)
+	}
+}
+
+// --- FilterIgnored ---
+
+func TestFilterIgnored(t *testing.T) {
+	tests := []struct {
+		name      string
+		apps      []*app.App
+		ignored   []string
+		wantCount int
+		wantNames []string
+	}{
+		{
+			name: "filters ignored apps",
+			apps: []*app.App{
+				{Name: "Keep1", BundleID: "com.keep1"},
+				{Name: "Ignore1", BundleID: "com.ignore1"},
+				{Name: "Keep2", BundleID: "com.keep2"},
+				{Name: "Ignore2", BundleID: "com.ignore2"},
+			},
+			ignored:   []string{"com.ignore1", "com.ignore2"},
+			wantCount: 2,
+			wantNames: []string{"Keep1", "Keep2"},
+		},
+		{
+			name: "no ignored apps",
+			apps: []*app.App{
+				{Name: "App1", BundleID: "com.app1"},
+				{Name: "App2", BundleID: "com.app2"},
+			},
+			ignored:   nil,
+			wantCount: 2,
+			wantNames: []string{"App1", "App2"},
+		},
+		{
+			name:      "empty apps list",
+			apps:      []*app.App{},
+			ignored:   []string{"com.something"},
+			wantCount: 0,
+		},
+		{
+			name: "all ignored",
+			apps: []*app.App{
+				{Name: "App1", BundleID: "com.app1"},
+			},
+			ignored:   []string{"com.app1"},
+			wantCount: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &config.Config{
+				IgnoredApps: tt.ignored,
+			}
+			// Build the internal ignored set by saving and reloading-style init.
+			// Use a helper approach: create config with buildIgnoredSet called.
+			// Since buildIgnoredSet is unexported, we use Load with a temp file or
+			// create a config that has the ignoredSet pre-populated.
+			// Actually, IsIgnored checks ignoredSet which is nil unless built.
+			// For testing, we can use the Load function or just create directly.
+			// Let's use a workaround: save to temp, load back.
+			if len(tt.ignored) > 0 {
+				tmpDir := t.TempDir()
+				path := tmpDir + "/config.yaml"
+				if err := cfg.Save(path); err != nil {
+					t.Fatalf("failed to save config: %v", err)
+				}
+				loaded, err := config.Load(path)
+				if err != nil {
+					t.Fatalf("failed to load config: %v", err)
+				}
+				cfg = loaded
+			}
+
+			result := FilterIgnored(tt.apps, cfg)
+			if len(result) != tt.wantCount {
+				t.Fatalf("got %d apps, want %d", len(result), tt.wantCount)
+			}
+			for i, wantName := range tt.wantNames {
+				if result[i].Name != wantName {
+					t.Errorf("result[%d].Name = %q, want %q", i, result[i].Name, wantName)
+				}
+			}
+		})
+	}
+}
+
+// --- BuildCheckers ---
+
+func TestBuildCheckers(t *testing.T) {
+	runner := &checker.MockCmdRunner{}
+	checkers := BuildCheckers(runner, "test-token")
+
+	if len(checkers) != 9 {
+		t.Fatalf("got %d checkers, want 9", len(checkers))
+	}
+
+	expectedNames := []string{
+		"sparkle",
+		"brew",
+		"mas",
+		"github",
+		"system",
+		"formula",
+		"electron",
+		"managed",
+		"brew-info",
+	}
+
+	for i, want := range expectedNames {
+		if checkers[i].Name() != want {
+			t.Errorf("checkers[%d].Name() = %q, want %q", i, checkers[i].Name(), want)
+		}
+	}
+}
+
+// --- CheckAll ---
+
+func TestCheckAll(t *testing.T) {
+	always := func(_ *app.App) bool { return true }
+	never := func(_ *app.App) bool { return false }
+
+	apps := []*app.App{
+		{Name: "App1", BundleID: "com.app1", Version: "1.0"},
+		{Name: "App2", BundleID: "com.app2", Version: "2.0"},
+		{Name: "App3", BundleID: "com.app3", Version: "3.0"},
+	}
+
+	checkers := []checker.Checker{
+		&mockChecker{
+			name:     "mock",
+			canCheck: always,
+			result: &checker.UpdateResult{
+				Source:         "mock",
+				LatestVersion:  "9.0",
+				HasUpdate:      true,
+			},
+		},
+	}
+
+	results := CheckAll(context.Background(), apps, checkers, 2)
+	if len(results) != 3 {
+		t.Fatalf("got %d results, want 3", len(results))
+	}
+
+	// Verify all results have the mock source.
+	for _, r := range results {
+		if r.Source != "mock" {
+			t.Errorf("result for %s has Source = %q, want %q", r.App.Name, r.Source, "mock")
+		}
+	}
+
+	// Test with no compatible checker — app should be skipped.
+	noCheckerApps := []*app.App{
+		{Name: "Skipped", BundleID: "com.skipped", Version: "1.0"},
+	}
+	noResults := CheckAll(context.Background(), noCheckerApps, []checker.Checker{
+		&mockChecker{name: "mock", canCheck: never},
+	}, 5)
+	if len(noResults) != 0 {
+		t.Errorf("got %d results, want 0 (no compatible checker)", len(noResults))
+	}
+}
+
+func TestCheckAll_DefaultConcurrency(t *testing.T) {
+	apps := []*app.App{
+		{Name: "App1", BundleID: "com.app1", Version: "1.0"},
+	}
+	checkers := []checker.Checker{
+		&mockChecker{
+			name:     "mock",
+			canCheck: func(_ *app.App) bool { return true },
+			result:   &checker.UpdateResult{Source: "mock", LatestVersion: "2.0"},
+		},
+	}
+
+	// maxConcurrency=0 should default to 10 and not panic.
+	results := CheckAll(context.Background(), apps, checkers, 0)
+	if len(results) != 1 {
+		t.Fatalf("got %d results, want 1", len(results))
+	}
+}
+
+func TestCheckAll_NegativeConcurrency(t *testing.T) {
+	apps := []*app.App{
+		{Name: "App1", BundleID: "com.app1", Version: "1.0"},
+	}
+	checkers := []checker.Checker{
+		&mockChecker{
+			name:     "mock",
+			canCheck: func(_ *app.App) bool { return true },
+			result:   &checker.UpdateResult{Source: "mock", LatestVersion: "2.0"},
+		},
+	}
+
+	// maxConcurrency=-1 should default to 10 and not panic.
+	results := CheckAll(context.Background(), apps, checkers, -1)
+	if len(results) != 1 {
+		t.Fatalf("got %d results, want 1", len(results))
+	}
+}
+
+func TestCheckAll_EmptyApps(t *testing.T) {
+	checkers := []checker.Checker{
+		&mockChecker{
+			name:     "mock",
+			canCheck: func(_ *app.App) bool { return true },
+			result:   &checker.UpdateResult{Source: "mock"},
+		},
+	}
+	results := CheckAll(context.Background(), nil, checkers, 5)
+	if len(results) != 0 {
+		t.Errorf("got %d results, want 0 for empty apps", len(results))
+	}
+}
+
+// --- CheckWithFallthrough ---
+
+func TestCheckWithFallthrough_Success(t *testing.T) {
+	a := &app.App{Name: "TestApp", Version: "1.0"}
+
+	checkers := []checker.Checker{
+		&mockChecker{
+			name:     "first",
+			canCheck: func(_ *app.App) bool { return true },
+			result: &checker.UpdateResult{
+				App:            a,
+				Source:         "first",
+				CurrentVersion: "1.0",
+				LatestVersion:  "2.0",
+				HasUpdate:      true,
+			},
+		},
+	}
+
+	result := CheckWithFallthrough(context.Background(), a, checkers)
+	if result.Error != nil {
+		t.Fatalf("unexpected error: %v", result.Error)
+	}
+	if result.Source != "first" {
+		t.Errorf("Source = %q, want %q", result.Source, "first")
+	}
+	if result.LatestVersion != "2.0" {
+		t.Errorf("LatestVersion = %q, want %q", result.LatestVersion, "2.0")
+	}
+}
+
+func TestCheckWithFallthrough_AllError(t *testing.T) {
+	a := &app.App{Name: "ErrorApp", Version: "1.0"}
+
+	checkers := []checker.Checker{
+		&mockChecker{
+			name:     "failing-checker",
+			canCheck: func(_ *app.App) bool { return true },
+			err:      fmt.Errorf("network timeout"),
+		},
+	}
+
+	result := CheckWithFallthrough(context.Background(), a, checkers)
+	if result.Error == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if result.Source != "failing-checker" {
+		t.Errorf("Source = %q, want %q", result.Source, "failing-checker")
+	}
+	if result.CurrentVersion != "1.0" {
+		t.Errorf("CurrentVersion = %q, want %q", result.CurrentVersion, "1.0")
+	}
+}
+
+func TestCheckWithFallthrough_MultipleErrors_LastErrorReturned(t *testing.T) {
+	a := &app.App{Name: "MultiErrorApp", Version: "1.0"}
+
+	checkers := []checker.Checker{
+		&mockChecker{
+			name:     "checker-1",
+			canCheck: func(_ *app.App) bool { return true },
+			err:      fmt.Errorf("first error"),
+		},
+		&mockChecker{
+			name:     "checker-2",
+			canCheck: func(_ *app.App) bool { return true },
+			err:      fmt.Errorf("second error"),
+		},
+	}
+
+	result := CheckWithFallthrough(context.Background(), a, checkers)
+	if result.Error == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if result.Source != "checker-2" {
+		t.Errorf("Source = %q, want %q (should be last checker)", result.Source, "checker-2")
+	}
+}
+
+func TestCheckWithFallthrough_AllStale(t *testing.T) {
+	a := &app.App{Name: "StaleApp", Version: "3.0"}
+
+	checkers := []checker.Checker{
+		&mockChecker{
+			name:     "stale-1",
+			canCheck: func(_ *app.App) bool { return true },
+			result: &checker.UpdateResult{
+				App:            a,
+				Source:         "stale-1",
+				CurrentVersion: "3.0",
+				LatestVersion:  "2.0",
+				StaleSource:    true,
+			},
+		},
+		&mockChecker{
+			name:     "stale-2",
+			canCheck: func(_ *app.App) bool { return true },
+			result: &checker.UpdateResult{
+				App:            a,
+				Source:         "stale-2",
+				CurrentVersion: "3.0",
+				LatestVersion:  "1.0",
+				StaleSource:    true,
+			},
+		},
+	}
+
+	result := CheckWithFallthrough(context.Background(), a, checkers)
+	if result.Error == nil {
+		t.Fatal("expected error for all-stale, got nil")
+	}
+	expected := "all 2 source(s) returned stale data for StaleApp"
+	if result.Error.Error() != expected {
+		t.Errorf("Error = %q, want %q", result.Error.Error(), expected)
+	}
+	if result.Source != "unknown" {
+		t.Errorf("Source = %q, want %q", result.Source, "unknown")
+	}
+}
+
+func TestCheckWithFallthrough_NoChecker(t *testing.T) {
+	a := &app.App{Name: "Orphan", Version: "1.0"}
+
+	// No checker can handle this app.
+	checkers := []checker.Checker{
+		&mockChecker{
+			name:     "incompatible",
+			canCheck: func(_ *app.App) bool { return false },
+		},
+	}
+
+	result := CheckWithFallthrough(context.Background(), a, checkers)
+	if result.Error == nil {
+		t.Fatal("expected error for no-checker, got nil")
+	}
+	expected := "no checker could provide a result for Orphan"
+	if result.Error.Error() != expected {
+		t.Errorf("Error = %q, want %q", result.Error.Error(), expected)
+	}
+	if result.Source != "unknown" {
+		t.Errorf("Source = %q, want %q", result.Source, "unknown")
+	}
+}
+
+func TestCheckWithFallthrough_EmptyCheckers(t *testing.T) {
+	a := &app.App{Name: "NoCheckers", Version: "1.0"}
+
+	result := CheckWithFallthrough(context.Background(), a, nil)
+	if result.Error == nil {
+		t.Fatal("expected error for empty checkers, got nil")
+	}
+	expected := "no checker could provide a result for NoCheckers"
+	if result.Error.Error() != expected {
+		t.Errorf("Error = %q, want %q", result.Error.Error(), expected)
+	}
+}
+
+func TestCheckWithFallthrough_ErrorThenSuccess(t *testing.T) {
+	a := &app.App{Name: "RecoverApp", Version: "1.0"}
+
+	checkers := []checker.Checker{
+		&mockChecker{
+			name:     "failing",
+			canCheck: func(_ *app.App) bool { return true },
+			err:      fmt.Errorf("temporary error"),
+		},
+		&mockChecker{
+			name:     "working",
+			canCheck: func(_ *app.App) bool { return true },
+			result: &checker.UpdateResult{
+				App:            a,
+				Source:         "working",
+				CurrentVersion: "1.0",
+				LatestVersion:  "2.0",
+				HasUpdate:      true,
+			},
+		},
+	}
+
+	result := CheckWithFallthrough(context.Background(), a, checkers)
+	if result.Error != nil {
+		t.Fatalf("unexpected error: %v", result.Error)
+	}
+	if result.Source != "working" {
+		t.Errorf("Source = %q, want %q", result.Source, "working")
+	}
+}
+
+func TestCheckWithFallthrough_StaleThenSuccess(t *testing.T) {
+	a := &app.App{Name: "StaleRecoverApp", Version: "2.0"}
+
+	checkers := []checker.Checker{
+		&mockChecker{
+			name:     "stale",
+			canCheck: func(_ *app.App) bool { return true },
+			result: &checker.UpdateResult{
+				App:         a,
+				Source:      "stale",
+				StaleSource: true,
+			},
+		},
+		&mockChecker{
+			name:     "fresh",
+			canCheck: func(_ *app.App) bool { return true },
+			result: &checker.UpdateResult{
+				App:            a,
+				Source:         "fresh",
+				CurrentVersion: "2.0",
+				LatestVersion:  "3.0",
+				HasUpdate:      true,
+			},
+		},
+	}
+
+	result := CheckWithFallthrough(context.Background(), a, checkers)
+	if result.Error != nil {
+		t.Fatalf("unexpected error: %v", result.Error)
+	}
+	if result.Source != "fresh" {
+		t.Errorf("Source = %q, want %q", result.Source, "fresh")
+	}
+}
+
+func TestCheckWithFallthrough_SkipsIncompatible(t *testing.T) {
+	a := &app.App{Name: "PartialApp", Version: "1.0"}
+
+	checkers := []checker.Checker{
+		&mockChecker{
+			name:     "incompatible",
+			canCheck: func(_ *app.App) bool { return false },
+		},
+		&mockChecker{
+			name:     "compatible",
+			canCheck: func(_ *app.App) bool { return true },
+			result: &checker.UpdateResult{
+				App:            a,
+				Source:         "compatible",
+				CurrentVersion: "1.0",
+				LatestVersion:  "2.0",
+				HasUpdate:      true,
+			},
+		},
+	}
+
+	result := CheckWithFallthrough(context.Background(), a, checkers)
+	if result.Error != nil {
+		t.Fatalf("unexpected error: %v", result.Error)
+	}
+	if result.Source != "compatible" {
+		t.Errorf("Source = %q, want %q", result.Source, "compatible")
+	}
+}
+
+func TestCheckWithFallthrough_MixedStaleAndError(t *testing.T) {
+	a := &app.App{Name: "MixedApp", Version: "1.0"}
+
+	checkers := []checker.Checker{
+		&mockChecker{
+			name:     "stale-checker",
+			canCheck: func(_ *app.App) bool { return true },
+			result: &checker.UpdateResult{
+				App:         a,
+				Source:      "stale-checker",
+				StaleSource: true,
+			},
+		},
+		&mockChecker{
+			name:     "error-checker",
+			canCheck: func(_ *app.App) bool { return true },
+			err:      fmt.Errorf("api error"),
+		},
+	}
+
+	result := CheckWithFallthrough(context.Background(), a, checkers)
+	if result.Error == nil {
+		t.Fatal("expected error, got nil")
+	}
+	// Last error should win over stale.
+	if result.Source != "error-checker" {
+		t.Errorf("Source = %q, want %q", result.Source, "error-checker")
+	}
+}
+
+// --- MacOSSystemApp ---
+
+func TestMacOSSystemApp(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("macOS-only test")
+	}
+
+	macOS := MacOSSystemApp()
+	if macOS == nil {
+		t.Fatal("MacOSSystemApp() returned nil on macOS")
+	}
+	if macOS.BundleID != "com.apple.macOS" {
+		t.Errorf("BundleID = %q, want %q", macOS.BundleID, "com.apple.macOS")
+	}
+	if macOS.Version == "" {
+		t.Error("Version is empty")
+	}
+	if macOS.Source != app.SourceSystem {
+		t.Errorf("Source = %q, want %q", macOS.Source, app.SourceSystem)
+	}
+	if macOS.Name != "macOS" {
+		t.Errorf("Name = %q, want %q", macOS.Name, "macOS")
+	}
+}
+
+// --- DiscoverApps ---
+
+func TestDiscoverApps(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("macOS-only test")
+	}
+
+	apps, err := DiscoverApps()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// /Applications should have at least a few apps on any macOS machine.
+	if len(apps) == 0 {
+		t.Fatal("expected at least one app, got 0")
+	}
+
+	// Verify macOS system entry is included.
+	var foundMacOS bool
+	for _, a := range apps {
+		if a.BundleID == "com.apple.macOS" {
+			foundMacOS = true
+			if a.Source != app.SourceSystem {
+				t.Errorf("macOS entry Source = %q, want %q", a.Source, app.SourceSystem)
+			}
+			break
+		}
+	}
+	if !foundMacOS {
+		t.Error("macOS system entry not found in discovered apps")
+	}
+}


### PR DESCRIPTION
## Summary
- **Menubar "Update All"**: New menu item with per-app progress labels, sequential updates, auto-refresh
- **Notify auto-update**: `--auto-update` flag runs safe updates after notification, schedule plist updated
- **Bulk rollback**: `--all` flag on `updater rollback` to restore all backed-up apps
- **Test coverage to 90%+**: app 98.8%, checker 95.5%, config 94.6%, history 92.3%, updater 96.7%

## Test plan
- [ ] `go vet ./...` — clean
- [ ] `go test -race ./...` — all pass
- [ ] `go test -cover ./internal/app/ ./internal/checker/ ./internal/config/ ./internal/history/ ./internal/updater/` — all ≥90%
- [ ] `updater rollback --all` — rolls back all backed-up apps
- [ ] Menubar: "Update All" item appears with count, updates sequentially with progress labels