### PR TITLE
feat: v0.8.0 — dry run, parallel updates, doctor validation, TUI rollback

### DIFF
--- a/cmd/updater/doctor.go
+++ b/cmd/updater/doctor.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/luzhengda/updater/internal/backup"
@@ -48,6 +49,9 @@ func runDoctor(cmd *cobra.Command, _ []string) error {
 
 	// Config file.
 	checks = append(checks, checkConfig())
+
+	// Config validation (cross-reference mappings with discovered apps).
+	checks = append(checks, checkConfigValidation()...)
 
 	// Backup directory.
 	checks = append(checks, checkBackups())
@@ -115,6 +119,54 @@ func checkConfig() doctorCheck {
 		return doctorCheck{Name: "Config", Status: "ok", Detail: "using defaults"}
 	}
 	return doctorCheck{Name: "Config", Status: "ok", Detail: cfgPath}
+}
+
+func checkConfigValidation() []doctorCheck {
+	cfg, err := config.Load(config.DefaultPath())
+	if err != nil {
+		return []doctorCheck{{Name: "Config validation", Status: "warning", Detail: fmt.Sprintf("cannot load config: %v", err)}}
+	}
+
+	// Discover apps for cross-reference.
+	apps, err := discoverApps()
+	if err != nil {
+		return []doctorCheck{{Name: "Config validation", Status: "warning", Detail: fmt.Sprintf("cannot discover apps: %v", err)}}
+	}
+
+	bundleIDs := make(map[string]bool, len(apps))
+	for _, a := range apps {
+		bundleIDs[a.BundleID] = true
+	}
+
+	var stale []string
+
+	for id := range cfg.GitHubMappings {
+		if !bundleIDs[id] {
+			stale = append(stale, fmt.Sprintf("github_mappings: %s", id))
+		}
+	}
+	for id := range cfg.CaskMappings {
+		if !bundleIDs[id] {
+			stale = append(stale, fmt.Sprintf("cask_mappings: %s", id))
+		}
+	}
+	for id := range cfg.Policies {
+		if !bundleIDs[id] {
+			stale = append(stale, fmt.Sprintf("policies: %s", id))
+		}
+	}
+	for _, id := range cfg.PinnedApps {
+		if !bundleIDs[id] {
+			stale = append(stale, fmt.Sprintf("pinned_apps: %s", id))
+		}
+	}
+
+	if len(stale) == 0 {
+		return []doctorCheck{{Name: "Config validation", Status: "ok", Detail: "all mappings valid"}}
+	}
+
+	detail := fmt.Sprintf("%d stale: %s", len(stale), strings.Join(stale, ", "))
+	return []doctorCheck{{Name: "Config validation", Status: "warning", Detail: detail}}
 }
 
 func checkBackups() doctorCheck {

--- a/cmd/updater/doctor.go
+++ b/cmd/updater/doctor.go
@@ -7,9 +7,11 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"time"
 
+	"github.com/luzhengda/updater/internal/app"
 	"github.com/luzhengda/updater/internal/backup"
 	"github.com/luzhengda/updater/internal/checker"
 	"github.com/luzhengda/updater/internal/config"
@@ -121,18 +123,21 @@ func checkConfig() doctorCheck {
 	return doctorCheck{Name: "Config", Status: "ok", Detail: cfgPath}
 }
 
+// checkConfigValidation discovers apps and cross-references config entries.
 func checkConfigValidation() []doctorCheck {
 	cfg, err := config.Load(config.DefaultPath())
 	if err != nil {
 		return []doctorCheck{{Name: "Config validation", Status: "warning", Detail: fmt.Sprintf("cannot load config: %v", err)}}
 	}
-
-	// Discover apps for cross-reference.
 	apps, err := discoverApps()
 	if err != nil {
 		return []doctorCheck{{Name: "Config validation", Status: "warning", Detail: fmt.Sprintf("cannot discover apps: %v", err)}}
 	}
+	return validateConfigMappings(cfg, apps)
+}
 
+// validateConfigMappings checks config entries against discovered app bundle IDs.
+func validateConfigMappings(cfg *config.Config, apps []*app.App) []doctorCheck {
 	bundleIDs := make(map[string]bool, len(apps))
 	for _, a := range apps {
 		bundleIDs[a.BundleID] = true
@@ -165,6 +170,7 @@ func checkConfigValidation() []doctorCheck {
 		return []doctorCheck{{Name: "Config validation", Status: "ok", Detail: "all mappings valid"}}
 	}
 
+	sort.Strings(stale) // deterministic output for tests
 	detail := fmt.Sprintf("%d stale: %s", len(stale), strings.Join(stale, ", "))
 	return []doctorCheck{{Name: "Config validation", Status: "warning", Detail: detail}}
 }

--- a/cmd/updater/doctor_test.go
+++ b/cmd/updater/doctor_test.go
@@ -9,7 +9,9 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/luzhengda/updater/internal/app"
 	"github.com/luzhengda/updater/internal/checker"
+	"github.com/luzhengda/updater/internal/config"
 	"github.com/luzhengda/updater/internal/history"
 )
 
@@ -118,5 +120,96 @@ func TestDoctor_AllToolsPresent(t *testing.T) {
 		if c.Status != "ok" {
 			t.Errorf("checkTool(%q) Status = %q, want %q", tool, c.Status, "ok")
 		}
+	}
+}
+
+func TestValidateConfigMappings_AllValid(t *testing.T) {
+	cfg := &config.Config{
+		GitHubMappings: map[string]string{"com.example.app": "owner/repo"},
+		CaskMappings:   map[string]string{"com.example.app": "my-cask"},
+	}
+	apps := []*app.App{
+		{BundleID: "com.example.app"},
+	}
+	checks := validateConfigMappings(cfg, apps)
+	if len(checks) != 1 {
+		t.Fatalf("expected 1 check, got %d", len(checks))
+	}
+	if checks[0].Status != "ok" {
+		t.Errorf("Status = %q, want %q", checks[0].Status, "ok")
+	}
+	if checks[0].Detail != "all mappings valid" {
+		t.Errorf("Detail = %q, want %q", checks[0].Detail, "all mappings valid")
+	}
+}
+
+func TestValidateConfigMappings_StaleGitHub(t *testing.T) {
+	cfg := &config.Config{
+		GitHubMappings: map[string]string{"com.stale.app": "owner/repo"},
+	}
+	apps := []*app.App{
+		{BundleID: "com.other.app"},
+	}
+	checks := validateConfigMappings(cfg, apps)
+	if len(checks) != 1 {
+		t.Fatalf("expected 1 check, got %d", len(checks))
+	}
+	if checks[0].Status != "warning" {
+		t.Errorf("Status = %q, want %q", checks[0].Status, "warning")
+	}
+	if !strings.Contains(checks[0].Detail, "github_mappings: com.stale.app") {
+		t.Errorf("Detail should mention stale github_mappings, got: %s", checks[0].Detail)
+	}
+}
+
+func TestValidateConfigMappings_StalePinned(t *testing.T) {
+	cfg := &config.Config{
+		PinnedApps: []string{"com.stale.pinned"},
+	}
+	apps := []*app.App{
+		{BundleID: "com.other.app"},
+	}
+	checks := validateConfigMappings(cfg, apps)
+	if checks[0].Status != "warning" {
+		t.Errorf("Status = %q, want %q", checks[0].Status, "warning")
+	}
+	if !strings.Contains(checks[0].Detail, "pinned_apps: com.stale.pinned") {
+		t.Errorf("Detail should mention stale pinned_apps, got: %s", checks[0].Detail)
+	}
+}
+
+func TestValidateConfigMappings_MultipleStale(t *testing.T) {
+	cfg := &config.Config{
+		GitHubMappings: map[string]string{"com.stale.gh": "owner/repo"},
+		Policies:       map[string]string{"com.stale.policy": config.PolicyManual},
+	}
+	apps := []*app.App{
+		{BundleID: "com.valid.app"},
+	}
+	checks := validateConfigMappings(cfg, apps)
+	if checks[0].Status != "warning" {
+		t.Errorf("Status = %q, want %q", checks[0].Status, "warning")
+	}
+	if !strings.Contains(checks[0].Detail, "2 stale") {
+		t.Errorf("Detail should say '2 stale', got: %s", checks[0].Detail)
+	}
+}
+
+func TestValidateConfigMappings_EmptyConfig(t *testing.T) {
+	cfg := &config.Config{}
+	apps := []*app.App{{BundleID: "com.example.app"}}
+	checks := validateConfigMappings(cfg, apps)
+	if checks[0].Status != "ok" {
+		t.Errorf("Status = %q, want %q", checks[0].Status, "ok")
+	}
+}
+
+func TestValidateConfigMappings_NoApps(t *testing.T) {
+	cfg := &config.Config{
+		GitHubMappings: map[string]string{"com.stale.app": "owner/repo"},
+	}
+	checks := validateConfigMappings(cfg, nil)
+	if checks[0].Status != "warning" {
+		t.Errorf("Status = %q, want %q", checks[0].Status, "warning")
 	}
 }

--- a/cmd/updater/ui.go
+++ b/cmd/updater/ui.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strings"
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/luzhengda/updater/internal/app"
@@ -105,10 +106,26 @@ func runUI(_ *cobra.Command, _ []string) error {
 		},
 	}
 
+	rollbackFn := func(ctx context.Context, appName string) error {
+		// Quit app if running.
+		apps, _ := discoverApps()
+		for _, a := range apps {
+			if strings.EqualFold(a.Name, appName) {
+				quitAppIfRunning(ctx, a, runner)
+				break
+			}
+		}
+		return bm.Restore(ctx, appName)
+	}
+
+	hasBackupFn := func(appName string) bool {
+		return bm.HasBackup(appName)
+	}
+
 	historyFn := func() ([]history.Entry, error) {
 		return history.List(history.DefaultPath())
 	}
-	model := tui.NewModel(loadFn, checkFn, updateFn, scheduleFns, cfg, cfgPath, historyFn)
+	model := tui.NewModel(loadFn, checkFn, updateFn, scheduleFns, cfg, cfgPath, rollbackFn, hasBackupFn, historyFn)
 	p := tea.NewProgram(model, tea.WithAltScreen())
 
 	if _, err := p.Run(); err != nil {

--- a/cmd/updater/update.go
+++ b/cmd/updater/update.go
@@ -41,6 +41,10 @@ func init() {
 }
 
 func runUpdate(cmd *cobra.Command, args []string) error {
+	if flagDryRunJSON && !flagDryRun {
+		return fmt.Errorf("--json requires --dry-run flag")
+	}
+
 	ctx := cmd.Context()
 
 	cfg, err := config.Load(config.DefaultPath())

--- a/cmd/updater/update.go
+++ b/cmd/updater/update.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"sync"
 	"text/tabwriter"
 	"time"
 
@@ -159,6 +160,15 @@ func runUpdate(cmd *cobra.Command, args []string) error {
 		return printDryRun(cmd, updatable, isExplicit, cfg)
 	}
 
+	// Split updates into sequential and parallel groups.
+	sequentialSources := map[string]bool{
+		"brew": true, "brew-info": true, "mas": true, "formula": true,
+	}
+	instantSources := map[string]bool{
+		"system": true, "setapp": true, "toolbox": true, "adobe": true,
+	}
+
+	var sequential, parallel, instant []*checker.UpdateResult
 	for _, r := range updatable {
 		if !isExplicit && cfg.IsPinned(r.App.BundleID) {
 			fmt.Fprintf(cmd.OutOrStdout(), "Skipping %s (pinned)\n", r.App.Name)
@@ -168,27 +178,40 @@ func runUpdate(cmd *cobra.Command, args []string) error {
 			fmt.Fprintf(cmd.OutOrStdout(), "Skipping %s (notify-only)\n", r.App.Name)
 			continue
 		}
-		fmt.Fprintf(cmd.OutOrStdout(), "Updating %s (%s -> %s) via %s...\n",
-			r.App.Name, r.CurrentVersion, r.LatestVersion, r.Source)
-
-		updateErr, rolledBack := executeUpdate(ctx, r, runner, bm, inst)
-		if errors.Is(updateErr, checker.ErrOpenedExternally) {
-			// Not an error — just opened externally for the user to handle.
-		} else if updateErr != nil {
-			fmt.Fprintf(os.Stderr, "  error: %v\n", updateErr)
+		switch {
+		case sequentialSources[r.Source]:
+			sequential = append(sequential, r)
+		case instantSources[r.Source]:
+			instant = append(instant, r)
+		default:
+			parallel = append(parallel, r)
 		}
+	}
 
-		// Record in update history (non-fatal on error).
-		_ = history.Append(history.DefaultPath(), history.Entry{
-			AppName:     r.App.Name,
-			BundleID:    r.App.BundleID,
-			FromVersion: r.CurrentVersion,
-			ToVersion:   r.LatestVersion,
-			Source:      r.Source,
-			Timestamp:   time.Now(),
-			Success:     updateErr == nil || errors.Is(updateErr, checker.ErrOpenedExternally),
-			RolledBack:  rolledBack,
-		})
+	// Phase 1: Sequential updates (brew, mas, formula — shared locks).
+	for _, r := range sequential {
+		performUpdate(cmd, ctx, r, runner, bm, inst)
+	}
+
+	// Phase 2: Parallel updates (sparkle, github, electron — independent).
+	if len(parallel) > 0 {
+		var wg sync.WaitGroup
+		sem := make(chan struct{}, 3) // limit concurrent installs
+		for _, r := range parallel {
+			wg.Add(1)
+			sem <- struct{}{}
+			go func(r *checker.UpdateResult) {
+				defer wg.Done()
+				defer func() { <-sem }()
+				performUpdate(cmd, ctx, r, runner, bm, inst)
+			}(r)
+		}
+		wg.Wait()
+	}
+
+	// Phase 3: Instant actions (system, setapp, toolbox, adobe — just open).
+	for _, r := range instant {
+		performUpdate(cmd, ctx, r, runner, bm, inst)
 	}
 
 	return nil
@@ -327,6 +350,30 @@ func executeUpdate(ctx context.Context, r *checker.UpdateResult, runner checker.
 	default:
 		return fmt.Errorf("unsupported update source: %s", r.Source), false
 	}
+}
+
+// performUpdate prints the update status, executes the update, and records the result in history.
+func performUpdate(cmd *cobra.Command, ctx context.Context, r *checker.UpdateResult, runner checker.CmdRunner, bm *backup.Manager, inst *installer.Installer) {
+	fmt.Fprintf(cmd.OutOrStdout(), "Updating %s (%s -> %s) via %s...\n",
+		r.App.Name, r.CurrentVersion, r.LatestVersion, r.Source)
+
+	updateErr, rolledBack := executeUpdate(ctx, r, runner, bm, inst)
+	if errors.Is(updateErr, checker.ErrOpenedExternally) {
+		// Not an error.
+	} else if updateErr != nil {
+		fmt.Fprintf(os.Stderr, "  error: %v\n", updateErr)
+	}
+
+	_ = history.Append(history.DefaultPath(), history.Entry{
+		AppName:     r.App.Name,
+		BundleID:    r.App.BundleID,
+		FromVersion: r.CurrentVersion,
+		ToVersion:   r.LatestVersion,
+		Source:      r.Source,
+		Timestamp:   time.Now(),
+		Success:     updateErr == nil || errors.Is(updateErr, checker.ErrOpenedExternally),
+		RolledBack:  rolledBack,
+	})
 }
 
 // rollbackAfterFailedInstall attempts to restore an app from backup after a failed install.

--- a/cmd/updater/update.go
+++ b/cmd/updater/update.go
@@ -2,10 +2,12 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
 	"strings"
+	"text/tabwriter"
 	"time"
 
 	"github.com/luzhengda/updater/internal/app"
@@ -18,8 +20,10 @@ import (
 )
 
 var (
-	flagAll  bool
-	flagAuto bool
+	flagAll        bool
+	flagAuto       bool
+	flagDryRun     bool
+	flagDryRunJSON bool
 )
 
 var updateCmd = &cobra.Command{
@@ -31,6 +35,8 @@ var updateCmd = &cobra.Command{
 func init() {
 	updateCmd.Flags().BoolVar(&flagAll, "all", false, "update all apps with available updates")
 	updateCmd.Flags().BoolVar(&flagAuto, "auto", false, "unattended mode (no prompts)")
+	updateCmd.Flags().BoolVar(&flagDryRun, "dry-run", false, "show what would be updated without making changes")
+	updateCmd.Flags().BoolVar(&flagDryRunJSON, "json", false, "output dry run results as JSON (requires --dry-run)")
 	rootCmd.AddCommand(updateCmd)
 }
 
@@ -144,6 +150,11 @@ func runUpdate(cmd *cobra.Command, args []string) error {
 
 	// Execute updates. When using --all, skip pinned apps unless explicitly named.
 	isExplicit := len(args) > 0 && !flagAll
+
+	if flagDryRun {
+		return printDryRun(cmd, updatable, isExplicit, cfg)
+	}
+
 	for _, r := range updatable {
 		if !isExplicit && cfg.IsPinned(r.App.BundleID) {
 			fmt.Fprintf(cmd.OutOrStdout(), "Skipping %s (pinned)\n", r.App.Name)
@@ -379,4 +390,102 @@ func quitAppIfRunning(ctx context.Context, a *app.App, runner checker.CmdRunner)
 // openForSelfUpdate opens an app so it can self-update via its built-in updater.
 func openForSelfUpdate(ctx context.Context, a *app.App, runner checker.CmdRunner) {
 	_, _ = runner.Run(ctx, "open", "-a", a.Path)
+}
+
+// describeAction returns a human-readable action string for each update source.
+func describeAction(r *checker.UpdateResult) string {
+	switch r.Source {
+	case "brew", "brew-info":
+		if r.App.InstalledViaBrew && r.App.CaskName != "" {
+			return fmt.Sprintf("brew upgrade --cask %s", r.App.CaskName)
+		}
+		return "open app for self-update"
+	case "mas":
+		if r.App.MASID != "" {
+			return fmt.Sprintf("mas upgrade %s", r.App.MASID)
+		}
+		return "open App Store"
+	case "formula":
+		return fmt.Sprintf("brew upgrade %s", r.App.FormulaName)
+	case "system":
+		return "open Software Update"
+	case "sparkle", "github":
+		if r.DownloadURL != "" && r.App.Path != "" {
+			return "direct install"
+		}
+		return "open download URL"
+	case "electron":
+		if r.DownloadURL != "" && r.App.Path != "" {
+			return "direct install"
+		}
+		return "open app for self-update"
+	case "setapp":
+		return "open Setapp"
+	case "toolbox":
+		return "open JetBrains Toolbox"
+	case "adobe":
+		return "open Adobe Creative Cloud"
+	default:
+		return "unsupported source"
+	}
+}
+
+// printDryRun displays what updates would be applied without making changes.
+func printDryRun(cmd *cobra.Command, updatable []*checker.UpdateResult, isExplicit bool, cfg *config.Config) error {
+	var planned []*checker.UpdateResult
+	for _, r := range updatable {
+		if !isExplicit && cfg.IsPinned(r.App.BundleID) {
+			continue
+		}
+		if !isExplicit && cfg.Policy(r.App.BundleID) == config.PolicyNotifyOnly {
+			continue
+		}
+		planned = append(planned, r)
+	}
+
+	if len(planned) == 0 {
+		fmt.Fprintln(cmd.OutOrStdout(), "DRY RUN — nothing to update.")
+		return nil
+	}
+
+	if flagDryRunJSON {
+		return printDryRunJSON(cmd, planned)
+	}
+
+	fmt.Fprintf(cmd.OutOrStdout(), "DRY RUN — no changes will be made\n\n")
+	w := tabwriter.NewWriter(cmd.OutOrStdout(), 0, 4, 2, ' ', 0)
+	fmt.Fprintln(w, "APP\tFROM\tTO\tSOURCE\tACTION")
+	for _, r := range planned {
+		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\n",
+			r.App.Name, r.CurrentVersion, r.LatestVersion, r.Source, describeAction(r))
+	}
+	w.Flush()
+	fmt.Fprintf(cmd.OutOrStdout(), "\n%d update(s) would be applied.\n", len(planned))
+	return nil
+}
+
+// dryRunEntry represents a single entry in the JSON dry-run output.
+type dryRunEntry struct {
+	App    string `json:"app"`
+	From   string `json:"from"`
+	To     string `json:"to"`
+	Source string `json:"source"`
+	Action string `json:"action"`
+}
+
+// printDryRunJSON outputs planned updates as a JSON array.
+func printDryRunJSON(cmd *cobra.Command, planned []*checker.UpdateResult) error {
+	entries := make([]dryRunEntry, len(planned))
+	for i, r := range planned {
+		entries[i] = dryRunEntry{
+			App:    r.App.Name,
+			From:   r.CurrentVersion,
+			To:     r.LatestVersion,
+			Source: r.Source,
+			Action: describeAction(r),
+		}
+	}
+	enc := json.NewEncoder(cmd.OutOrStdout())
+	enc.SetIndent("", "  ")
+	return enc.Encode(entries)
 }

--- a/cmd/updater/update_test.go
+++ b/cmd/updater/update_test.go
@@ -1,17 +1,21 @@
 package main
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/luzhengda/updater/internal/app"
 	"github.com/luzhengda/updater/internal/backup"
 	"github.com/luzhengda/updater/internal/checker"
+	"github.com/luzhengda/updater/internal/config"
+	"github.com/spf13/cobra"
 )
 
 // createFakeBackup manually creates a backup directory structure that
@@ -126,5 +130,417 @@ func TestRollback_NilManager(t *testing.T) {
 	rolledBack := rollbackAfterFailedInstall(context.Background(), nil, "TestApp")
 	if rolledBack {
 		t.Error("expected rollback to return false with nil manager")
+	}
+}
+
+func TestDescribeAction(t *testing.T) {
+	tests := []struct {
+		name   string
+		result *checker.UpdateResult
+		want   string
+	}{
+		{
+			name: "brew cask installed via brew",
+			result: &checker.UpdateResult{
+				App:    &app.App{CaskName: "firefox", InstalledViaBrew: true},
+				Source: "brew",
+			},
+			want: "brew upgrade --cask firefox",
+		},
+		{
+			name: "brew not installed via brew",
+			result: &checker.UpdateResult{
+				App:    &app.App{CaskName: "firefox", InstalledViaBrew: false},
+				Source: "brew",
+			},
+			want: "open app for self-update",
+		},
+		{
+			name: "brew-info installed via brew",
+			result: &checker.UpdateResult{
+				App:    &app.App{CaskName: "iterm2", InstalledViaBrew: true},
+				Source: "brew-info",
+			},
+			want: "brew upgrade --cask iterm2",
+		},
+		{
+			name: "brew-info not installed via brew",
+			result: &checker.UpdateResult{
+				App:    &app.App{InstalledViaBrew: false},
+				Source: "brew-info",
+			},
+			want: "open app for self-update",
+		},
+		{
+			name: "mas with MASID",
+			result: &checker.UpdateResult{
+				App:    &app.App{MASID: "441258766"},
+				Source: "mas",
+			},
+			want: "mas upgrade 441258766",
+		},
+		{
+			name: "mas without MASID",
+			result: &checker.UpdateResult{
+				App:    &app.App{},
+				Source: "mas",
+			},
+			want: "open App Store",
+		},
+		{
+			name: "formula",
+			result: &checker.UpdateResult{
+				App:    &app.App{FormulaName: "node"},
+				Source: "formula",
+			},
+			want: "brew upgrade node",
+		},
+		{
+			name: "system",
+			result: &checker.UpdateResult{
+				App:    &app.App{},
+				Source: "system",
+			},
+			want: "open Software Update",
+		},
+		{
+			name: "sparkle with download URL and path",
+			result: &checker.UpdateResult{
+				App:         &app.App{Path: "/Applications/App.app"},
+				Source:      "sparkle",
+				DownloadURL: "https://example.com/app.dmg",
+			},
+			want: "direct install",
+		},
+		{
+			name: "sparkle without download URL",
+			result: &checker.UpdateResult{
+				App:    &app.App{Path: "/Applications/App.app"},
+				Source: "sparkle",
+			},
+			want: "open download URL",
+		},
+		{
+			name: "github with download URL and path",
+			result: &checker.UpdateResult{
+				App:         &app.App{Path: "/Applications/App.app"},
+				Source:      "github",
+				DownloadURL: "https://github.com/owner/repo/releases/download/v1.0/app.dmg",
+			},
+			want: "direct install",
+		},
+		{
+			name: "github without download URL",
+			result: &checker.UpdateResult{
+				App:    &app.App{},
+				Source: "github",
+			},
+			want: "open download URL",
+		},
+		{
+			name: "electron with download URL and path",
+			result: &checker.UpdateResult{
+				App:         &app.App{Path: "/Applications/App.app"},
+				Source:      "electron",
+				DownloadURL: "https://example.com/app.dmg",
+			},
+			want: "direct install",
+		},
+		{
+			name: "electron without download URL",
+			result: &checker.UpdateResult{
+				App:    &app.App{},
+				Source: "electron",
+			},
+			want: "open app for self-update",
+		},
+		{
+			name: "setapp",
+			result: &checker.UpdateResult{
+				App:    &app.App{},
+				Source: "setapp",
+			},
+			want: "open Setapp",
+		},
+		{
+			name: "toolbox",
+			result: &checker.UpdateResult{
+				App:    &app.App{},
+				Source: "toolbox",
+			},
+			want: "open JetBrains Toolbox",
+		},
+		{
+			name: "adobe",
+			result: &checker.UpdateResult{
+				App:    &app.App{},
+				Source: "adobe",
+			},
+			want: "open Adobe Creative Cloud",
+		},
+		{
+			name: "unknown source",
+			result: &checker.UpdateResult{
+				App:    &app.App{},
+				Source: "something-else",
+			},
+			want: "unsupported source",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := describeAction(tt.result)
+			if got != tt.want {
+				t.Errorf("describeAction() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestPrintDryRun_Table(t *testing.T) {
+	cmd := &cobra.Command{}
+	buf := &bytes.Buffer{}
+	cmd.SetOut(buf)
+
+	cfg := &config.Config{}
+
+	updatable := []*checker.UpdateResult{
+		{
+			App:            &app.App{Name: "Firefox", BundleID: "org.mozilla.firefox", CaskName: "firefox", InstalledViaBrew: true},
+			Source:         "brew",
+			CurrentVersion: "120.0",
+			LatestVersion:  "121.0",
+		},
+		{
+			App:            &app.App{Name: "Keynote", BundleID: "com.apple.iWork.Keynote", MASID: "409183694"},
+			Source:         "mas",
+			CurrentVersion: "13.0",
+			LatestVersion:  "14.0",
+		},
+	}
+
+	err := printDryRun(cmd, updatable, false, cfg)
+	if err != nil {
+		t.Fatalf("printDryRun() error = %v", err)
+	}
+
+	out := buf.String()
+
+	// Verify header columns.
+	for _, header := range []string{"APP", "FROM", "TO", "SOURCE", "ACTION"} {
+		if !strings.Contains(out, header) {
+			t.Errorf("output missing header %q", header)
+		}
+	}
+
+	// Verify content rows.
+	if !strings.Contains(out, "Firefox") {
+		t.Error("output missing Firefox")
+	}
+	if !strings.Contains(out, "120.0") {
+		t.Error("output missing version 120.0")
+	}
+	if !strings.Contains(out, "121.0") {
+		t.Error("output missing version 121.0")
+	}
+	if !strings.Contains(out, "brew upgrade --cask firefox") {
+		t.Error("output missing brew upgrade action")
+	}
+	if !strings.Contains(out, "Keynote") {
+		t.Error("output missing Keynote")
+	}
+	if !strings.Contains(out, "mas upgrade 409183694") {
+		t.Error("output missing mas upgrade action")
+	}
+	if !strings.Contains(out, "DRY RUN") {
+		t.Error("output missing DRY RUN header")
+	}
+	if !strings.Contains(out, "2 update(s) would be applied") {
+		t.Error("output missing update count summary")
+	}
+}
+
+func TestPrintDryRun_JSON(t *testing.T) {
+	flagDryRunJSON = true
+	defer func() { flagDryRunJSON = false }()
+
+	cmd := &cobra.Command{}
+	buf := &bytes.Buffer{}
+	cmd.SetOut(buf)
+
+	cfg := &config.Config{}
+
+	updatable := []*checker.UpdateResult{
+		{
+			App:            &app.App{Name: "Firefox", BundleID: "org.mozilla.firefox", CaskName: "firefox", InstalledViaBrew: true},
+			Source:         "brew",
+			CurrentVersion: "120.0",
+			LatestVersion:  "121.0",
+		},
+	}
+
+	err := printDryRun(cmd, updatable, false, cfg)
+	if err != nil {
+		t.Fatalf("printDryRun() error = %v", err)
+	}
+
+	var entries []dryRunEntry
+	if err := json.Unmarshal(buf.Bytes(), &entries); err != nil {
+		t.Fatalf("failed to parse JSON output: %v\n%s", err, buf.String())
+	}
+
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(entries))
+	}
+
+	e := entries[0]
+	if e.App != "Firefox" {
+		t.Errorf("App = %q, want %q", e.App, "Firefox")
+	}
+	if e.From != "120.0" {
+		t.Errorf("From = %q, want %q", e.From, "120.0")
+	}
+	if e.To != "121.0" {
+		t.Errorf("To = %q, want %q", e.To, "121.0")
+	}
+	if e.Source != "brew" {
+		t.Errorf("Source = %q, want %q", e.Source, "brew")
+	}
+	if e.Action != "brew upgrade --cask firefox" {
+		t.Errorf("Action = %q, want %q", e.Action, "brew upgrade --cask firefox")
+	}
+}
+
+func TestPrintDryRun_Empty(t *testing.T) {
+	cmd := &cobra.Command{}
+	buf := &bytes.Buffer{}
+	cmd.SetOut(buf)
+
+	cfg := &config.Config{}
+	cfg.Pin("com.test.pinned")
+
+	// All apps are pinned — nothing to update.
+	updatable := []*checker.UpdateResult{
+		{
+			App:            &app.App{Name: "PinnedApp", BundleID: "com.test.pinned"},
+			Source:         "brew",
+			CurrentVersion: "1.0",
+			LatestVersion:  "2.0",
+		},
+	}
+
+	err := printDryRun(cmd, updatable, false, cfg)
+	if err != nil {
+		t.Fatalf("printDryRun() error = %v", err)
+	}
+
+	out := buf.String()
+	if !strings.Contains(out, "nothing to update") {
+		t.Errorf("expected 'nothing to update' message, got: %s", out)
+	}
+}
+
+func TestPrintDryRun_SkipsPinned(t *testing.T) {
+	cmd := &cobra.Command{}
+	buf := &bytes.Buffer{}
+	cmd.SetOut(buf)
+
+	cfg := &config.Config{}
+	cfg.Pin("com.test.pinned")
+
+	updatable := []*checker.UpdateResult{
+		{
+			App:            &app.App{Name: "PinnedApp", BundleID: "com.test.pinned", CaskName: "pinned", InstalledViaBrew: true},
+			Source:         "brew",
+			CurrentVersion: "1.0",
+			LatestVersion:  "2.0",
+		},
+		{
+			App:            &app.App{Name: "NormalApp", BundleID: "com.test.normal", CaskName: "normal", InstalledViaBrew: true},
+			Source:         "brew",
+			CurrentVersion: "3.0",
+			LatestVersion:  "4.0",
+		},
+	}
+
+	err := printDryRun(cmd, updatable, false, cfg)
+	if err != nil {
+		t.Fatalf("printDryRun() error = %v", err)
+	}
+
+	out := buf.String()
+	if strings.Contains(out, "PinnedApp") {
+		t.Error("pinned app should be excluded from dry run output")
+	}
+	if !strings.Contains(out, "NormalApp") {
+		t.Error("normal app should be included in dry run output")
+	}
+	if !strings.Contains(out, "1 update(s) would be applied") {
+		t.Errorf("expected 1 update count, got: %s", out)
+	}
+}
+
+func TestPrintDryRun_SkipsNotifyOnly(t *testing.T) {
+	cmd := &cobra.Command{}
+	buf := &bytes.Buffer{}
+	cmd.SetOut(buf)
+
+	cfg := &config.Config{}
+	cfg.SetPolicy("com.test.notify", config.PolicyNotifyOnly)
+
+	updatable := []*checker.UpdateResult{
+		{
+			App:            &app.App{Name: "NotifyApp", BundleID: "com.test.notify", CaskName: "notify", InstalledViaBrew: true},
+			Source:         "brew",
+			CurrentVersion: "1.0",
+			LatestVersion:  "2.0",
+		},
+		{
+			App:            &app.App{Name: "AutoApp", BundleID: "com.test.auto", CaskName: "auto", InstalledViaBrew: true},
+			Source:         "brew",
+			CurrentVersion: "5.0",
+			LatestVersion:  "6.0",
+		},
+	}
+
+	err := printDryRun(cmd, updatable, false, cfg)
+	if err != nil {
+		t.Fatalf("printDryRun() error = %v", err)
+	}
+
+	out := buf.String()
+	if strings.Contains(out, "NotifyApp") {
+		t.Error("notify-only app should be excluded from dry run output")
+	}
+	if !strings.Contains(out, "AutoApp") {
+		t.Error("auto app should be included in dry run output")
+	}
+}
+
+func TestRunUpdate_JSONRequiresDryRun(t *testing.T) {
+	// Save and restore global flags.
+	origJSON := flagDryRunJSON
+	origDryRun := flagDryRun
+	defer func() {
+		flagDryRunJSON = origJSON
+		flagDryRun = origDryRun
+	}()
+
+	flagDryRunJSON = true
+	flagDryRun = false
+
+	cmd := &cobra.Command{
+		RunE: runUpdate,
+	}
+	buf := &bytes.Buffer{}
+	cmd.SetOut(buf)
+
+	err := cmd.RunE(cmd, nil)
+	if err == nil {
+		t.Fatal("expected error when --json used without --dry-run")
+	}
+	if !strings.Contains(err.Error(), "--json requires --dry-run") {
+		t.Errorf("unexpected error message: %v", err)
 	}
 }

--- a/docs/plans/2026-02-15-v0.8.0-design.md
+++ b/docs/plans/2026-02-15-v0.8.0-design.md
@@ -1,0 +1,63 @@
+# v0.8.0 Design: Dry Run, Parallel Updates, Doctor Config Validation, TUI Rollback
+
+## 1. Dry Run Mode
+
+Add `--dry-run` flag to `updater update`. Runs the full check pipeline but prints what would be updated without executing. Default table output; `--json` flag for structured JSON.
+
+Table output:
+```
+DRY RUN — no changes will be made
+
+APP                FROM      TO        SOURCE    ACTION
+Firefox            133.0     134.0     brew      brew upgrade --cask firefox
+iTerm2             3.5.0     3.6.6     sparkle   direct install (DMG)
+macOS              15.3      15.3.1    system    open Software Update
+
+3 updates would be applied.
+```
+
+JSON output: array of `{app, from, to, source, action}` objects.
+
+Applies to `--all`, `--auto`, and single-app modes. Pinned/policy filtering still applies.
+
+## 2. Parallel Update Support
+
+Split updates into two execution groups:
+
+- **Sequential**: `brew`, `brew-info`, `mas`, `formula` — share external package manager locks
+- **Parallel**: `sparkle`, `github`, `electron` — independent direct installs, run concurrently with semaphore (max 3)
+- **Instant**: `system`, `setapp`, `toolbox`, `adobe` — just open external apps, fire immediately
+
+Execution order: sequential first, then parallel, then instant. No new config option.
+
+## 3. Config Validation in Doctor
+
+New `checkConfigValidation()` in doctor that discovers apps and cross-references config entries:
+
+- Stale `github_mappings` bundle IDs not matching any discovered app
+- Stale `cask_mappings` bundle IDs not matching any discovered app
+- Unknown `policies` bundle IDs not matching any discovered app
+- Unknown `pinned_apps` bundle IDs not matching any discovered app
+
+Output: `[ok] Config mappings (all valid)` or `[!!] Config mappings (N stale: ...)`.
+
+Requires `discoverApps()` inside doctor (~1s overhead, acceptable for diagnostic tool).
+
+## 4. TUI Rollback
+
+Rollback action in the detail view overlay. Press `r` while viewing app detail.
+
+Flow:
+1. `r` in detail view -> check backup exists via `HasBackupFunc`
+2. No backup -> status message "No backup available for X"
+3. Backup exists -> confirmation "Rollback X to previous version? (y/n)"
+4. `y` -> async rollback via `RollbackFunc`, show spinner
+5. Result -> status message "Rolled back X" or "Rollback failed: ..."
+
+New callbacks:
+```go
+type RollbackFunc func(ctx context.Context, appName string) error
+type HasBackupFunc func(appName string) bool
+```
+
+Detail view help bar shows `r:rollback` when backup exists.

--- a/docs/plans/2026-02-15-v0.8.0-plan.md
+++ b/docs/plans/2026-02-15-v0.8.0-plan.md
@@ -1,0 +1,642 @@
+# v0.8.0 Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add dry run mode, parallel update execution, doctor config validation, and TUI rollback.
+
+**Architecture:** Dry run adds a `--dry-run` flag that reuses the existing check pipeline and prints planned actions without executing. Parallel updates splits `executeUpdate` calls into sequential (brew/mas/formula) and parallel (sparkle/github/electron) groups. Doctor config validation cross-references config entries against discovered apps. TUI rollback adds `RollbackFunc`/`HasBackupFunc` callbacks and a confirmation flow in the detail view.
+
+**Tech Stack:** Go, Cobra CLI, Bubbletea TUI, tabwriter
+
+---
+
+## Task 1: Dry Run Mode — `--dry-run` flag and action descriptions
+
+**Files:**
+- Modify: `cmd/updater/update.go`
+
+**Context:** The `runUpdate` function at line 37 handles `--all`, `--auto`, and single-app modes. After filtering to `updatable` results, it loops through and calls `executeUpdate`. Dry run intercepts before `executeUpdate` and prints planned actions instead.
+
+**Implementation:**
+
+Add flag and action description helper:
+
+```go
+var flagDryRun bool
+
+// In init():
+updateCmd.Flags().BoolVar(&flagDryRun, "dry-run", false, "show what would be updated without making changes")
+```
+
+Add `describeAction` function that returns a human-readable action string for each source:
+
+```go
+func describeAction(r *checker.UpdateResult) string {
+	switch r.Source {
+	case "brew", "brew-info":
+		if r.App.InstalledViaBrew && r.App.CaskName != "" {
+			return fmt.Sprintf("brew upgrade --cask %s", r.App.CaskName)
+		}
+		return "open app for self-update"
+	case "mas":
+		if r.App.MASID != "" {
+			return fmt.Sprintf("mas upgrade %s", r.App.MASID)
+		}
+		return "open App Store"
+	case "formula":
+		return fmt.Sprintf("brew upgrade %s", r.App.FormulaName)
+	case "system":
+		return "open Software Update"
+	case "sparkle", "github":
+		if r.DownloadURL != "" && r.App.Path != "" {
+			return "direct install"
+		}
+		return "open download URL"
+	case "electron":
+		if r.DownloadURL != "" && r.App.Path != "" {
+			return "direct install"
+		}
+		return "open app for self-update"
+	case "setapp":
+		return "open Setapp"
+	case "toolbox":
+		return "open JetBrains Toolbox"
+	case "adobe":
+		return "open Adobe Creative Cloud"
+	default:
+		return "unsupported source"
+	}
+}
+```
+
+In `runUpdate`, after the `updatable` filtering and before the `executeUpdate` loop (around line 146), add the dry run branch:
+
+```go
+if flagDryRun {
+	return printDryRun(cmd, updatable, isExplicit, cfg)
+}
+```
+
+Add `printDryRun` function:
+
+```go
+func printDryRun(cmd *cobra.Command, updatable []*checker.UpdateResult, isExplicit bool, cfg *config.Config) error {
+	// Apply same pinned/policy skipping as the real update loop.
+	var planned []*checker.UpdateResult
+	for _, r := range updatable {
+		if !isExplicit && cfg.IsPinned(r.App.BundleID) {
+			continue
+		}
+		if !isExplicit && cfg.Policy(r.App.BundleID) == config.PolicyNotifyOnly {
+			continue
+		}
+		planned = append(planned, r)
+	}
+
+	if len(planned) == 0 {
+		fmt.Fprintln(cmd.OutOrStdout(), "DRY RUN — nothing to update.")
+		return nil
+	}
+
+	if flagDryRunJSON {
+		return printDryRunJSON(cmd, planned)
+	}
+
+	fmt.Fprintln(cmd.OutOrStdout(), "DRY RUN — no changes will be made\n")
+	w := tabwriter.NewWriter(cmd.OutOrStdout(), 0, 4, 2, ' ', 0)
+	fmt.Fprintln(w, "APP\tFROM\tTO\tSOURCE\tACTION")
+	for _, r := range planned {
+		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\n",
+			r.App.Name, r.CurrentVersion, r.LatestVersion, r.Source, describeAction(r))
+	}
+	w.Flush()
+	fmt.Fprintf(cmd.OutOrStdout(), "\n%d update(s) would be applied.\n", len(planned))
+	return nil
+}
+```
+
+Also add `--json` support for dry run:
+
+```go
+var flagDryRunJSON bool
+
+// In init():
+updateCmd.Flags().BoolVar(&flagDryRunJSON, "json", false, "output dry run results as JSON (requires --dry-run)")
+```
+
+```go
+type dryRunEntry struct {
+	App     string `json:"app"`
+	From    string `json:"from"`
+	To      string `json:"to"`
+	Source  string `json:"source"`
+	Action  string `json:"action"`
+}
+
+func printDryRunJSON(cmd *cobra.Command, planned []*checker.UpdateResult) error {
+	entries := make([]dryRunEntry, len(planned))
+	for i, r := range planned {
+		entries[i] = dryRunEntry{
+			App:    r.App.Name,
+			From:   r.CurrentVersion,
+			To:     r.LatestVersion,
+			Source: r.Source,
+			Action: describeAction(r),
+		}
+	}
+	enc := json.NewEncoder(cmd.OutOrStdout())
+	enc.SetIndent("", "  ")
+	return enc.Encode(entries)
+}
+```
+
+Add `"encoding/json"` and `"text/tabwriter"` to imports.
+
+**Verify:** `go vet ./cmd/updater/ && go test -race ./cmd/updater/`
+
+---
+
+## Task 2: Dry Run Mode — Tests
+
+**Files:**
+- Modify: `cmd/updater/update_test.go` (or create if needed)
+
+**Tests:**
+
+```go
+func TestDescribeAction(t *testing.T) {
+	tests := []struct {
+		name   string
+		result *checker.UpdateResult
+		want   string
+	}{
+		{
+			name:   "brew cask installed via brew",
+			result: &checker.UpdateResult{Source: "brew", App: &app.App{CaskName: "firefox", InstalledViaBrew: true}},
+			want:   "brew upgrade --cask firefox",
+		},
+		{
+			name:   "brew not installed via brew",
+			result: &checker.UpdateResult{Source: "brew", App: &app.App{CaskName: "firefox"}},
+			want:   "open app for self-update",
+		},
+		{
+			name:   "mas with ID",
+			result: &checker.UpdateResult{Source: "mas", App: &app.App{MASID: "441258766"}},
+			want:   "mas upgrade 441258766",
+		},
+		{
+			name:   "formula",
+			result: &checker.UpdateResult{Source: "formula", App: &app.App{FormulaName: "node"}},
+			want:   "brew upgrade node",
+		},
+		{
+			name:   "system",
+			result: &checker.UpdateResult{Source: "system", App: &app.App{}},
+			want:   "open Software Update",
+		},
+		{
+			name:   "sparkle with download URL",
+			result: &checker.UpdateResult{Source: "sparkle", DownloadURL: "https://x.com/app.dmg", App: &app.App{Path: "/Applications/X.app"}},
+			want:   "direct install",
+		},
+		{
+			name:   "sparkle without download URL",
+			result: &checker.UpdateResult{Source: "sparkle", App: &app.App{}},
+			want:   "open download URL",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := describeAction(tt.result)
+			if got != tt.want {
+				t.Errorf("describeAction() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+```
+
+**Verify:** `go test -race ./cmd/updater/ -run TestDescribeAction`
+
+---
+
+## Task 3: Parallel Update Support
+
+**Files:**
+- Modify: `cmd/updater/update.go`
+
+**Context:** The update loop at line 147 runs `executeUpdate` sequentially for each result. We need to split into sequential and parallel groups.
+
+**Implementation:**
+
+Replace the sequential loop (lines 147-177) with a grouped execution:
+
+```go
+// Split updates into sequential and parallel groups.
+sequentialSources := map[string]bool{
+	"brew": true, "brew-info": true, "mas": true, "formula": true,
+}
+instantSources := map[string]bool{
+	"system": true, "setapp": true, "toolbox": true, "adobe": true,
+}
+
+var sequential, parallel, instant []*checker.UpdateResult
+for _, r := range updatable {
+	if !isExplicit && cfg.IsPinned(r.App.BundleID) {
+		fmt.Fprintf(cmd.OutOrStdout(), "Skipping %s (pinned)\n", r.App.Name)
+		continue
+	}
+	if !isExplicit && cfg.Policy(r.App.BundleID) == config.PolicyNotifyOnly {
+		fmt.Fprintf(cmd.OutOrStdout(), "Skipping %s (notify-only)\n", r.App.Name)
+		continue
+	}
+	switch {
+	case sequentialSources[r.Source]:
+		sequential = append(sequential, r)
+	case instantSources[r.Source]:
+		instant = append(instant, r)
+	default:
+		parallel = append(parallel, r)
+	}
+}
+
+// Phase 1: Sequential updates (brew, mas, formula — shared locks).
+for _, r := range sequential {
+	performUpdate(cmd, ctx, r, runner, bm, inst)
+}
+
+// Phase 2: Parallel updates (sparkle, github, electron — independent).
+if len(parallel) > 0 {
+	var wg sync.WaitGroup
+	sem := make(chan struct{}, 3) // limit concurrent installs
+	for _, r := range parallel {
+		wg.Add(1)
+		sem <- struct{}{}
+		go func(r *checker.UpdateResult) {
+			defer wg.Done()
+			defer func() { <-sem }()
+			performUpdate(cmd, ctx, r, runner, bm, inst)
+		}(r)
+	}
+	wg.Wait()
+}
+
+// Phase 3: Instant actions (system, setapp, toolbox, adobe — just open).
+for _, r := range instant {
+	performUpdate(cmd, ctx, r, runner, bm, inst)
+}
+```
+
+Extract the per-update logic into `performUpdate`:
+
+```go
+func performUpdate(cmd *cobra.Command, ctx context.Context, r *checker.UpdateResult, runner checker.CmdRunner, bm *backup.Manager, inst *installer.Installer) {
+	fmt.Fprintf(cmd.OutOrStdout(), "Updating %s (%s -> %s) via %s...\n",
+		r.App.Name, r.CurrentVersion, r.LatestVersion, r.Source)
+
+	updateErr, rolledBack := executeUpdate(ctx, r, runner, bm, inst)
+	if errors.Is(updateErr, checker.ErrOpenedExternally) {
+		// Not an error.
+	} else if updateErr != nil {
+		fmt.Fprintf(os.Stderr, "  error: %v\n", updateErr)
+	}
+
+	_ = history.Append(history.DefaultPath(), history.Entry{
+		AppName:     r.App.Name,
+		BundleID:    r.App.BundleID,
+		FromVersion: r.CurrentVersion,
+		ToVersion:   r.LatestVersion,
+		Source:      r.Source,
+		Timestamp:   time.Now(),
+		Success:     updateErr == nil || errors.Is(updateErr, checker.ErrOpenedExternally),
+		RolledBack:  rolledBack,
+	})
+}
+```
+
+Add `"sync"` to imports.
+
+**Verify:** `go vet ./cmd/updater/ && go test -race ./cmd/updater/`
+
+---
+
+## Task 4: Doctor Config Validation
+
+**Files:**
+- Modify: `cmd/updater/doctor.go`
+
+**Context:** The `runDoctor` function at line 38 runs a series of checks. We add a new `checkConfigValidation` that discovers apps and cross-references config entries.
+
+**Implementation:**
+
+Add the check call in `runDoctor`, after the existing config check (line 50):
+
+```go
+// Config validation (cross-reference mappings with discovered apps).
+checks = append(checks, checkConfigValidation()...)
+```
+
+Add the validation function:
+
+```go
+func checkConfigValidation() []doctorCheck {
+	cfg, err := config.Load(config.DefaultPath())
+	if err != nil {
+		return []doctorCheck{{Name: "Config validation", Status: "warning", Detail: fmt.Sprintf("cannot load config: %v", err)}}
+	}
+
+	// Discover apps for cross-reference.
+	apps, err := discoverApps()
+	if err != nil {
+		return []doctorCheck{{Name: "Config validation", Status: "warning", Detail: fmt.Sprintf("cannot discover apps: %v", err)}}
+	}
+
+	bundleIDs := make(map[string]bool, len(apps))
+	for _, a := range apps {
+		bundleIDs[a.BundleID] = true
+	}
+
+	var stale []string
+
+	for id := range cfg.GitHubMappings {
+		if !bundleIDs[id] {
+			stale = append(stale, fmt.Sprintf("github_mappings: %s", id))
+		}
+	}
+	for id := range cfg.CaskMappings {
+		if !bundleIDs[id] {
+			stale = append(stale, fmt.Sprintf("cask_mappings: %s", id))
+		}
+	}
+	for id := range cfg.Policies {
+		if !bundleIDs[id] {
+			stale = append(stale, fmt.Sprintf("policies: %s", id))
+		}
+	}
+	for _, id := range cfg.PinnedApps {
+		if !bundleIDs[id] {
+			stale = append(stale, fmt.Sprintf("pinned_apps: %s", id))
+		}
+	}
+
+	if len(stale) == 0 {
+		return []doctorCheck{{Name: "Config validation", Status: "ok", Detail: "all mappings valid"}}
+	}
+
+	detail := fmt.Sprintf("%d stale: %s", len(stale), strings.Join(stale, ", "))
+	return []doctorCheck{{Name: "Config validation", Status: "warning", Detail: detail}}
+}
+```
+
+Add `"strings"` to imports.
+
+**Verify:** `go vet ./cmd/updater/ && go test -race ./cmd/updater/`
+
+---
+
+## Task 5: Doctor Config Validation — Tests
+
+**Files:**
+- Modify: `cmd/updater/doctor_test.go` (or create)
+
+**Tests:**
+
+```go
+func TestCheckConfigValidation_AllValid(t *testing.T) {
+	// This is difficult to unit test without mocking discoverApps,
+	// so we test the function integration-style.
+	// When run without any config, it should return "ok".
+	checks := checkConfigValidation()
+	if len(checks) == 0 {
+		t.Fatal("expected at least one check result")
+	}
+	// With default config (no mappings), should be "ok".
+	if checks[0].Status != "ok" {
+		t.Errorf("Status = %q, want %q", checks[0].Status, "ok")
+	}
+}
+```
+
+**Verify:** `go test -race ./cmd/updater/ -run TestCheckConfigValidation`
+
+---
+
+## Task 6: TUI Rollback — Model Changes
+
+**Files:**
+- Modify: `internal/tui/tui.go`
+
+**Context:** The Model struct at line 89 has callbacks for load, check, update, schedule, and history. We add rollback callbacks and state.
+
+**Implementation:**
+
+Add callback types after `HistoryFunc` (line 51):
+
+```go
+// RollbackFunc executes a rollback for a single app by name.
+type RollbackFunc func(ctx context.Context, appName string) error
+
+// HasBackupFunc checks whether a backup exists for the given app.
+type HasBackupFunc func(appName string) bool
+```
+
+Add message type after `historyLoadedMsg` (line 78):
+
+```go
+type rollbackDoneMsg struct {
+	appName string
+	err     error
+}
+```
+
+Add fields to `Model` struct (after `historyOffset`):
+
+```go
+rollbackFn       RollbackFunc
+hasBackupFn      HasBackupFunc
+rollbackConfirm  bool   // true when showing y/n confirmation
+rollbackAppName  string // app being rolled back
+rollingBack      bool   // true while rollback is in progress
+```
+
+Update `NewModel` signature to accept the new callbacks. Since this is the 8th+ parameter, add them as variadic options or add to the existing variadic pattern. Best approach: add as explicit params before the variadic `historyFn`:
+
+Change signature from:
+```go
+func NewModel(loadFn LoadFunc, checkFn CheckFunc, updateFn UpdateFunc, scheduleFns *ScheduleFuncs, cfg *config.Config, cfgPath string, historyFn ...HistoryFunc) Model {
+```
+to:
+```go
+func NewModel(loadFn LoadFunc, checkFn CheckFunc, updateFn UpdateFunc, scheduleFns *ScheduleFuncs, cfg *config.Config, cfgPath string, rollbackFn RollbackFunc, hasBackupFn HasBackupFunc, historyFn ...HistoryFunc) Model {
+```
+
+In the `NewModel` body, set:
+```go
+rollbackFn:  rollbackFn,
+hasBackupFn: hasBackupFn,
+```
+
+**Verify:** This will break `cmd/updater/ui.go` — fix in Task 7.
+
+---
+
+## Task 7: TUI Rollback — Wire Up and Key Handling
+
+**Files:**
+- Modify: `cmd/updater/ui.go` (wire up callbacks)
+- Modify: `internal/tui/tui.go` (key handling, view)
+
+**Wire up in `cmd/updater/ui.go`:**
+
+Add rollback callbacks before the `NewModel` call:
+
+```go
+rollbackFn := func(ctx context.Context, appName string) error {
+	// Quit app if running.
+	apps, _ := discoverApps()
+	for _, a := range apps {
+		if strings.EqualFold(a.Name, appName) {
+			quitAppIfRunning(ctx, a, runner)
+			break
+		}
+	}
+	return bm.Restore(ctx, appName)
+}
+
+hasBackupFn := func(appName string) bool {
+	return bm.HasBackup(appName)
+}
+```
+
+Update `NewModel` call:
+```go
+model := tui.NewModel(loadFn, checkFn, updateFn, scheduleFns, cfg, cfgPath, rollbackFn, hasBackupFn, historyFn)
+```
+
+Add `"strings"` to imports.
+
+**Key handling in `internal/tui/tui.go`:**
+
+In `handleDetailKey` (line 486), add `r` key case inside `case tea.KeyRunes`:
+
+```go
+case "r":
+	if m.hasBackupFn == nil || m.rollbackFn == nil {
+		return m, nil
+	}
+	idx := m.detailIdx
+	if idx >= len(m.rows) {
+		return m, nil
+	}
+	appName := m.rows[idx].app.Name
+	if !m.hasBackupFn(appName) {
+		m.statusMsg = fmt.Sprintf("No backup available for %s", appName)
+		m.showDetail = false
+		return m, nil
+	}
+	m.rollbackConfirm = true
+	m.rollbackAppName = appName
+	return m, nil
+```
+
+Add new handler for rollback confirmation, called from `Update` when `rollbackConfirm` is true:
+
+```go
+func (m Model) handleRollbackConfirmKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	switch msg.Type {
+	case tea.KeyCtrlC:
+		return m, tea.Quit
+	case tea.KeyEsc:
+		m.rollbackConfirm = false
+		return m, nil
+	case tea.KeyRunes:
+		switch string(msg.Runes) {
+		case "y":
+			m.rollbackConfirm = false
+			m.rollingBack = true
+			m.showDetail = false
+			appName := m.rollbackAppName
+			return m, func() tea.Msg {
+				err := m.rollbackFn(context.Background(), appName)
+				return rollbackDoneMsg{appName: appName, err: err}
+			}
+		case "n":
+			m.rollbackConfirm = false
+			return m, nil
+		}
+	}
+	return m, nil
+}
+```
+
+In the `Update` method, handle `rollbackDoneMsg`:
+
+```go
+case rollbackDoneMsg:
+	m.rollingBack = false
+	if msg.err != nil {
+		m.statusMsg = fmt.Sprintf("Rollback failed for %s: %v", msg.appName, msg.err)
+	} else {
+		m.statusMsg = fmt.Sprintf("Rolled back %s to previous version", msg.appName)
+	}
+	return m, nil
+```
+
+In the `Update` method's key handling dispatch, add before the detail key check:
+
+```go
+if m.rollbackConfirm {
+	return m.handleRollbackConfirmKey(msg)
+}
+```
+
+**View updates in `viewDetail`:**
+
+Update the help bar (line 1008) to show rollback option when backup exists:
+
+```go
+helpText := "j/k: scroll | d/esc/q: back"
+if m.hasBackupFn != nil && m.detailIdx < len(m.rows) {
+	if m.hasBackupFn(m.rows[m.detailIdx].app.Name) {
+		helpText = "j/k: scroll | r: rollback | d/esc/q: back"
+	}
+}
+if m.rollbackConfirm {
+	helpText = fmt.Sprintf("Rollback %s to previous version? (y/n)", m.rollbackAppName)
+}
+b.WriteString(styleStatusBar.Render(helpText))
+```
+
+If `m.rollingBack`, show spinner in status:
+
+```go
+if m.rollingBack {
+	b.WriteString(styleStatusBar.Render(fmt.Sprintf("%s Rolling back %s...", m.spinner.View(), m.rollbackAppName)))
+}
+```
+
+**Verify:** `go vet ./... && go test -race ./...`
+
+---
+
+## Implementation Order
+
+```
+Task 1 → Task 2 (dry run, sequential)
+Task 3 (parallel updates, independent)
+Task 4 → Task 5 (doctor validation, sequential)
+Task 6 → Task 7 (TUI rollback, sequential)
+```
+
+Tasks 1-2, 3, 4-5, and 6-7 are independent groups that could be implemented in any order.
+
+## Verification
+
+After all tasks:
+1. `go vet ./...` — clean
+2. `go test -race ./...` — all pass
+3. `updater update --all --dry-run` — shows planned updates
+4. `updater update --all --dry-run --json` — valid JSON output
+5. `updater doctor` — shows config validation check
+6. TUI: enter detail view → press `r` → confirmation prompt → rollback

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -50,6 +50,12 @@ type ScheduleFuncs struct {
 // HistoryFunc loads update history entries.
 type HistoryFunc func() ([]history.Entry, error)
 
+// RollbackFunc executes a rollback for a single app by name.
+type RollbackFunc func(ctx context.Context, appName string) error
+
+// HasBackupFunc checks whether a backup exists for the given app.
+type HasBackupFunc func(appName string) bool
+
 // row represents a single row in the TUI table.
 type row struct {
 	app      *app.App
@@ -75,6 +81,11 @@ type updateDoneMsg struct {
 
 type historyLoadedMsg struct {
 	entries []history.Entry
+	err     error
+}
+
+type rollbackDoneMsg struct {
+	appName string
 	err     error
 }
 
@@ -119,10 +130,15 @@ type Model struct {
 	searchMode     bool
 	searchInput    textinput.Model
 	searchQuery    string
-	historyFn      HistoryFunc
-	showHistory    bool
-	historyEntries []history.Entry
-	historyOffset  int
+	historyFn        HistoryFunc
+	showHistory      bool
+	historyEntries   []history.Entry
+	historyOffset    int
+	rollbackFn       RollbackFunc
+	hasBackupFn      HasBackupFunc
+	rollbackConfirm  bool   // true when showing y/n confirmation
+	rollbackAppName  string // app being rolled back
+	rollingBack      bool   // true while rollback is in progress
 }
 
 // NewModel creates a new TUI model that launches instantly.
@@ -130,7 +146,7 @@ type Model struct {
 // checkFn runs after loading to check for updates.
 // updateFn executes updates for individual apps.
 // scheduleFns, cfg, and cfgPath are optional — pass nil/empty to disable scheduler UI.
-func NewModel(loadFn LoadFunc, checkFn CheckFunc, updateFn UpdateFunc, scheduleFns *ScheduleFuncs, cfg *config.Config, cfgPath string, historyFn ...HistoryFunc) Model {
+func NewModel(loadFn LoadFunc, checkFn CheckFunc, updateFn UpdateFunc, scheduleFns *ScheduleFuncs, cfg *config.Config, cfgPath string, rollbackFn RollbackFunc, hasBackupFn HasBackupFunc, historyFn ...HistoryFunc) Model {
 	s := spinner.New()
 	s.Spinner = spinner.Dot
 	s.Style = lipgloss.NewStyle().Foreground(colorCyan)
@@ -161,6 +177,8 @@ func NewModel(loadFn LoadFunc, checkFn CheckFunc, updateFn UpdateFunc, scheduleF
 		cfgPath:     cfgPath,
 		searchInput: ti,
 		historyFn:   hFn,
+		rollbackFn:  rollbackFn,
+		hasBackupFn: hasBackupFn,
 	}
 }
 

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -289,7 +289,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 
 	case spinner.TickMsg:
-		if m.loading || m.checking || len(m.updating) > 0 {
+		if m.loading || m.checking || len(m.updating) > 0 || m.rollingBack {
 			var cmd tea.Cmd
 			m.spinner, cmd = m.spinner.Update(msg)
 			return m, cmd
@@ -386,6 +386,15 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, m.spinner.Tick
 		}
 		return m, nil
+
+	case rollbackDoneMsg:
+		m.rollingBack = false
+		if msg.err != nil {
+			m.statusMsg = fmt.Sprintf("Rollback failed for %s: %v", msg.appName, msg.err)
+		} else {
+			m.statusMsg = fmt.Sprintf("Rolled back %s to previous version", msg.appName)
+		}
+		return m, nil
 	}
 
 	return m, nil
@@ -406,6 +415,11 @@ func (m Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	// History overlay.
 	if m.showHistory {
 		return m.handleHistoryKey(msg)
+	}
+
+	// Rollback confirmation overlay.
+	if m.rollbackConfirm {
+		return m.handleRollbackConfirmKey(msg)
 	}
 
 	// In detail view, handle viewport scrolling and escape.
@@ -519,6 +533,23 @@ func (m Model) handleDetailKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		case "k":
 			m.detailViewport.LineUp(1)
 			return m, nil
+		case "r":
+			if m.hasBackupFn == nil || m.rollbackFn == nil {
+				return m, nil
+			}
+			idx := m.detailIdx
+			if idx >= len(m.rows) {
+				return m, nil
+			}
+			appName := m.rows[idx].app.Name
+			if !m.hasBackupFn(appName) {
+				m.statusMsg = fmt.Sprintf("No backup available for %s", appName)
+				m.showDetail = false
+				return m, nil
+			}
+			m.rollbackConfirm = true
+			m.rollbackAppName = appName
+			return m, nil
 		}
 	case tea.KeyDown:
 		m.detailViewport.LineDown(1)
@@ -526,6 +557,33 @@ func (m Model) handleDetailKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case tea.KeyUp:
 		m.detailViewport.LineUp(1)
 		return m, nil
+	}
+	return m, nil
+}
+
+// handleRollbackConfirmKey processes keyboard input during the rollback confirmation overlay.
+func (m Model) handleRollbackConfirmKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	switch msg.Type {
+	case tea.KeyCtrlC:
+		return m, tea.Quit
+	case tea.KeyEsc:
+		m.rollbackConfirm = false
+		return m, nil
+	case tea.KeyRunes:
+		switch string(msg.Runes) {
+		case "y":
+			m.rollbackConfirm = false
+			m.rollingBack = true
+			m.showDetail = false
+			appName := m.rollbackAppName
+			return m, func() tea.Msg {
+				err := m.rollbackFn(context.Background(), appName)
+				return rollbackDoneMsg{appName: appName, err: err}
+			}
+		case "n":
+			m.rollbackConfirm = false
+			return m, nil
+		}
 	}
 	return m, nil
 }
@@ -938,6 +996,15 @@ func (m Model) View() string {
 		return m.viewDetail()
 	}
 
+	if m.rollingBack {
+		var b strings.Builder
+		b.WriteString(styleHeader.Render("macOS App Updater"))
+		b.WriteString("\n")
+		b.WriteString(m.spinner.View())
+		b.WriteString(fmt.Sprintf(" Rolling back %s...\n", m.rollbackAppName))
+		return b.String()
+	}
+
 	var b strings.Builder
 
 	// Header.
@@ -1023,7 +1090,16 @@ func (m Model) viewDetail() string {
 	b.WriteString("\n")
 	b.WriteString(m.detailViewport.View())
 	b.WriteString("\n")
-	b.WriteString(styleStatusBar.Render("j/k: scroll | d/esc/q: back"))
+	helpText := "j/k: scroll | d/esc/q: back"
+	if m.hasBackupFn != nil && m.detailIdx < len(m.rows) {
+		if m.hasBackupFn(m.rows[m.detailIdx].app.Name) {
+			helpText = "j/k: scroll | r: rollback | d/esc/q: back"
+		}
+	}
+	if m.rollbackConfirm {
+		helpText = fmt.Sprintf("Rollback %s to previous version? (y/n)", m.rollbackAppName)
+	}
+	b.WriteString(styleStatusBar.Render(helpText))
 
 	return b.String()
 }


### PR DESCRIPTION
## Summary

- **Dry run mode**: `--dry-run` flag on `updater update` shows what would be updated without executing. Supports `--json` for structured output.
- **Parallel updates**: Direct installs (sparkle/github/electron) now run concurrently (max 3), while brew/mas/formula remain sequential to avoid lock conflicts.
- **Doctor config validation**: `updater doctor` cross-references config mappings (github_mappings, cask_mappings, policies, pinned_apps) against discovered apps, flagging stale entries.
- **TUI rollback**: Press `r` in the detail view to rollback an app to its previous version (with y/n confirmation and spinner).

## Test Plan
- [x] `go vet ./...` clean
- [x] `go test -race ./...` all pass
- [ ] `updater update --all --dry-run` — shows planned updates table
- [ ] `updater update --all --dry-run --json` — valid JSON output
- [ ] `updater doctor` — shows config validation check
- [ ] TUI: detail view → press `r` → confirmation → rollback

🤖 Generated with [Claude Code](https://claude.com/claude-code)