### PR TITLE
feat: v0.10.0 — scan --json, TUI source filter, notification config, CLI tests

### DIFF
--- a/cmd/updater/check_test.go
+++ b/cmd/updater/check_test.go
@@ -168,3 +168,30 @@ func TestToCheckEntries_DownloadURL(t *testing.T) {
 		t.Errorf("ReleaseNotes = %q, want %q", e.ReleaseNotes, "Bug fixes and performance improvements")
 	}
 }
+
+func TestCliSourceName(t *testing.T) {
+	tests := []struct {
+		source string
+		want   string
+	}{
+		{"mas", "app store"},
+		{"brew", "homebrew"},
+		{"brew-info", "homebrew"},
+		{"formula", "formula"},
+		{"sparkle", "sparkle"},
+		{"github", "github"},
+		{"electron", "electron"},
+		{"setapp", "setapp"},
+		{"toolbox", "toolbox"},
+		{"adobe", "adobe"},
+		{"unknown", "unknown"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.source, func(t *testing.T) {
+			got := cliSourceName(tt.source)
+			if got != tt.want {
+				t.Errorf("cliSourceName(%q) = %q, want %q", tt.source, got, tt.want)
+			}
+		})
+	}
+}

--- a/cmd/updater/config_cmd_test.go
+++ b/cmd/updater/config_cmd_test.go
@@ -1,0 +1,97 @@
+package main
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/lu-zhengda/updater/internal/config"
+	"gopkg.in/yaml.v3"
+)
+
+func TestConfigExport_MarshalRoundtrip(t *testing.T) {
+	cfg := &config.Config{
+		GitHubMappings: map[string]string{"com.test": "owner/repo"},
+		PinnedApps:     []string{"com.pinned"},
+	}
+	data, err := yaml.Marshal(cfg)
+	if err != nil {
+		t.Fatalf("marshal failed: %v", err)
+	}
+	if !strings.Contains(string(data), "com.test") {
+		t.Error("expected github mapping in output")
+	}
+	if !strings.Contains(string(data), "com.pinned") {
+		t.Error("expected pinned app in output")
+	}
+
+	// Verify round-trip
+	var decoded config.Config
+	if err := yaml.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("unmarshal failed: %v", err)
+	}
+	if decoded.GitHubMappings["com.test"] != "owner/repo" {
+		t.Errorf("github mapping = %q, want %q", decoded.GitHubMappings["com.test"], "owner/repo")
+	}
+}
+
+func TestConfigImport_WriteRead(t *testing.T) {
+	tmpFile := t.TempDir() + "/test-config.yaml"
+
+	cfg := &config.Config{
+		PinnedApps:     []string{"com.app1"},
+		GitHubMappings: map[string]string{"com.app2": "owner/repo"},
+	}
+	data, _ := yaml.Marshal(cfg)
+	if err := os.WriteFile(tmpFile, data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Read back
+	readData, err := os.ReadFile(tmpFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var imported config.Config
+	if err := yaml.Unmarshal(readData, &imported); err != nil {
+		t.Fatalf("unmarshal failed: %v", err)
+	}
+	if len(imported.PinnedApps) != 1 || imported.PinnedApps[0] != "com.app1" {
+		t.Errorf("pinned apps = %v, want [com.app1]", imported.PinnedApps)
+	}
+}
+
+func TestConfigMerge_ImportOverrides(t *testing.T) {
+	current := &config.Config{
+		GitHubMappings: map[string]string{"com.existing": "old/repo"},
+		PinnedApps:     []string{"com.pinned1"},
+	}
+	imported := &config.Config{
+		GitHubMappings: map[string]string{"com.existing": "new/repo", "com.new": "new/other"},
+		PinnedApps:     []string{"com.pinned2"},
+	}
+
+	merged := config.Merge(current, imported)
+
+	// Map: imported overrides
+	if merged.GitHubMappings["com.existing"] != "new/repo" {
+		t.Errorf("existing mapping should be overridden, got %q", merged.GitHubMappings["com.existing"])
+	}
+	if merged.GitHubMappings["com.new"] != "new/other" {
+		t.Error("new mapping should be added")
+	}
+	// List: union + dedup
+	hasPinned1, hasPinned2 := false, false
+	for _, p := range merged.PinnedApps {
+		if p == "com.pinned1" {
+			hasPinned1 = true
+		}
+		if p == "com.pinned2" {
+			hasPinned2 = true
+		}
+	}
+	if !hasPinned1 || !hasPinned2 {
+		t.Errorf("pinned should be union, got %v", merged.PinnedApps)
+	}
+}

--- a/cmd/updater/notify.go
+++ b/cmd/updater/notify.go
@@ -79,7 +79,7 @@ func runNotify(cmd *cobra.Command, _ []string) error {
 	body := buildNotificationBody(updatable)
 	subtitle := buildNotificationSubtitle(updatable)
 
-	if flagInteractive {
+	if flagInteractive || cfg.InteractiveNotifications {
 		return sendInteractiveNotification(ctx, runner, len(updatable), body)
 	}
 	if err := sendNotification(ctx, runner, len(updatable), body, subtitle); err != nil {

--- a/cmd/updater/notify_test.go
+++ b/cmd/updater/notify_test.go
@@ -7,6 +7,8 @@ import (
 
 	"github.com/lu-zhengda/updater/internal/app"
 	"github.com/lu-zhengda/updater/internal/checker"
+	"github.com/lu-zhengda/updater/internal/config"
+	"gopkg.in/yaml.v3"
 )
 
 func TestBuildNotificationBody(t *testing.T) {
@@ -210,6 +212,22 @@ func TestRunNotify_AutoUpdateFlag(t *testing.T) {
 	}
 	if f.DefValue != "false" {
 		t.Errorf("default = %q, want %q", f.DefValue, "false")
+	}
+}
+
+func TestInteractiveNotificationsConfig(t *testing.T) {
+	cfg := &config.Config{InteractiveNotifications: true}
+	if !cfg.InteractiveNotifications {
+		t.Error("expected InteractiveNotifications to be true")
+	}
+
+	// Verify YAML serialization
+	data, err := yaml.Marshal(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(data), "interactive_notifications: true") {
+		t.Errorf("expected yaml to contain interactive_notifications, got: %s", string(data))
 	}
 }
 

--- a/cmd/updater/policy_test.go
+++ b/cmd/updater/policy_test.go
@@ -1,0 +1,28 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/lu-zhengda/updater/internal/config"
+)
+
+func TestPolicyCommand_InvalidPolicy(t *testing.T) {
+	// Verify the valid policies map
+	validPolicies := map[string]bool{
+		config.PolicyAuto: true, config.PolicyManual: true, config.PolicyNotifyOnly: true, "clear": true,
+	}
+
+	invalid := []string{"skip", "always", "never", ""}
+	for _, p := range invalid {
+		if validPolicies[p] {
+			t.Errorf("policy %q should be invalid", p)
+		}
+	}
+
+	valid := []string{"auto", "manual", "notify-only", "clear"}
+	for _, p := range valid {
+		if !validPolicies[p] {
+			t.Errorf("policy %q should be valid", p)
+		}
+	}
+}

--- a/cmd/updater/scan.go
+++ b/cmd/updater/scan.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"text/tabwriter"
@@ -9,6 +10,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var flagScanJSON bool
+
 var scanCmd = &cobra.Command{
 	Use:   "scan",
 	Short: "Discover installed apps and their update sources",
@@ -16,6 +19,7 @@ var scanCmd = &cobra.Command{
 }
 
 func init() {
+	scanCmd.Flags().BoolVar(&flagScanJSON, "json", false, "output results as JSON")
 	rootCmd.AddCommand(scanCmd)
 }
 
@@ -35,6 +39,29 @@ func runScan(cmd *cobra.Command, args []string) error {
 		apps = append(apps, formulaApps...)
 	}
 
+	if flagScanJSON {
+		entries := make([]scanEntry, len(apps))
+		for i, a := range apps {
+			entries[i] = scanEntry{
+				Name:             a.Name,
+				BundleID:         a.BundleID,
+				Version:          a.Version,
+				Source:           string(a.Source),
+				FeedURL:          a.FeedURL,
+				GitHubRepo:       a.GitHubRepo,
+				CaskName:         a.CaskName,
+				InstalledViaBrew: a.InstalledViaBrew,
+			}
+		}
+		enc := json.NewEncoder(cmd.OutOrStdout())
+		enc.SetIndent("", "  ")
+		if err := enc.Encode(entries); err != nil {
+			return fmt.Errorf("failed to encode JSON: %w", err)
+		}
+		fmt.Fprintf(os.Stderr, "%d apps discovered\n", len(apps))
+		return nil
+	}
+
 	w := tabwriter.NewWriter(cmd.OutOrStdout(), 0, 4, 2, ' ', 0)
 	fmt.Fprintln(w, "NAME\tVERSION\tSOURCE\tBUNDLE ID")
 	for _, a := range apps {
@@ -44,4 +71,16 @@ func runScan(cmd *cobra.Command, args []string) error {
 
 	fmt.Fprintf(os.Stderr, "\n%d apps discovered\n", len(apps))
 	return nil
+}
+
+// scanEntry is the JSON representation of a discovered app.
+type scanEntry struct {
+	Name             string `json:"name"`
+	BundleID         string `json:"bundle_id"`
+	Version          string `json:"version"`
+	Source           string `json:"source"`
+	FeedURL          string `json:"feed_url,omitempty"`
+	GitHubRepo       string `json:"github_repo,omitempty"`
+	CaskName         string `json:"cask_name,omitempty"`
+	InstalledViaBrew bool   `json:"installed_via_brew"`
 }

--- a/cmd/updater/scan_test.go
+++ b/cmd/updater/scan_test.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestScanEntryJSON(t *testing.T) {
+	// Verify scanEntry marshals correctly with omitempty.
+	entry := scanEntry{
+		Name:             "Firefox",
+		BundleID:         "org.mozilla.firefox",
+		Version:          "134.0",
+		Source:           "brew",
+		InstalledViaBrew: true,
+	}
+	data, err := json.Marshal(entry)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(data), `"installed_via_brew":true`) {
+		t.Error("expected installed_via_brew")
+	}
+	if strings.Contains(string(data), `"feed_url"`) {
+		t.Error("empty feed_url should be omitted")
+	}
+	if strings.Contains(string(data), `"github_repo"`) {
+		t.Error("empty github_repo should be omitted")
+	}
+	if strings.Contains(string(data), `"cask_name"`) {
+		t.Error("empty cask_name should be omitted")
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -28,8 +28,9 @@ type Config struct {
 	ScheduleOffered  bool              `yaml:"schedule_offered"`
 	ScheduleInterval int               `yaml:"schedule_interval"`
 	LastChecked      time.Time         `yaml:"last_checked,omitempty"`
-	Policies         map[string]string `yaml:"policies,omitempty"` // bundleID → "auto"|"manual"|"notify-only"
-	ignoredSet       map[string]bool   `yaml:"-"`
+	Policies                 map[string]string `yaml:"policies,omitempty"` // bundleID → "auto"|"manual"|"notify-only"
+	InteractiveNotifications bool              `yaml:"interactive_notifications"`
+	ignoredSet               map[string]bool   `yaml:"-"`
 	pinnedSet        map[string]bool   `yaml:"-"`
 }
 

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -64,6 +64,9 @@ type row struct {
 	updating bool
 }
 
+// sourceFilterCycle defines the order in which the source filter cycles.
+var sourceFilterCycle = []string{"", "sparkle", "brew", "github", "mas", "system", "formula", "electron"}
+
 // Messages sent by background operations.
 type loadDoneMsg struct {
 	result *LoadResult
@@ -140,6 +143,7 @@ type Model struct {
 	rollbackAppName  string // app being rolled back
 	rollingBack      bool   // true while rollback is in progress
 	showHelp         bool   // true when help overlay is visible
+	sourceFilter     string // current source filter (empty = show all)
 }
 
 // NewModel creates a new TUI model that launches instantly.
@@ -489,6 +493,9 @@ func (m Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			return m, nil
 		case "h":
 			return m.openHistory()
+		case "f":
+			m.cycleSourceFilter()
+			return m, nil
 		case "/":
 			m.searchMode = true
 			m.searchInput.Focus()
@@ -834,6 +841,25 @@ func (m *Model) toggleShowAll() {
 	}
 }
 
+// cycleSourceFilter advances the source filter to the next value in the cycle.
+func (m *Model) cycleSourceFilter() {
+	current := 0
+	for i, s := range sourceFilterCycle {
+		if s == m.sourceFilter {
+			current = i
+			break
+		}
+	}
+	next := (current + 1) % len(sourceFilterCycle)
+	m.sourceFilter = sourceFilterCycle[next]
+	m.rebuildVisible()
+	if m.sourceFilter == "" {
+		m.statusMsg = "Showing all sources"
+	} else {
+		m.statusMsg = fmt.Sprintf("Filtering: %s", m.sourceFilter)
+	}
+}
+
 // handleUpdate starts updates for selected apps, or the cursor row if none selected.
 func (m Model) handleUpdate() (tea.Model, tea.Cmd) {
 	if m.checking {
@@ -968,6 +994,23 @@ func (m *Model) rebuildVisible() {
 		// Apply search filter.
 		if query != "" && !strings.Contains(strings.ToLower(r.app.Name), query) {
 			continue
+		}
+		// Apply source filter.
+		if m.sourceFilter != "" {
+			source := ""
+			if r.result != nil {
+				source = r.result.Source
+			} else {
+				source = string(r.app.Source)
+			}
+			// Match brew-info to brew filter, and include +brew suffix sources
+			if m.sourceFilter == "brew" {
+				if source != "brew" && source != "brew-info" && !strings.HasSuffix(source, "+brew") {
+					continue
+				}
+			} else if source != m.sourceFilter {
+				continue
+			}
 		}
 		if m.showAll {
 			m.visible = append(m.visible, i)
@@ -1278,6 +1321,12 @@ func (m Model) renderStatusBar() string {
 		helpParts = append(helpParts, "h: history")
 	}
 
+	if m.sourceFilter != "" {
+		helpParts = append(helpParts, fmt.Sprintf("f: filter (%s)", m.sourceFilter))
+	} else {
+		helpParts = append(helpParts, "f: filter")
+	}
+
 	helpParts = append(helpParts, "/: search", "?: help", "r: refresh", "q: quit")
 
 	// Append last-checked timestamp.
@@ -1390,6 +1439,7 @@ func (m Model) viewHelp() string {
 	b.WriteString(styleColumnHeader.Render("  Views"))
 	b.WriteString("\n")
 	b.WriteString("    t           Toggle show all / actionable\n")
+	b.WriteString("    f           Cycle source filter\n")
 	b.WriteString("    h           Update history\n")
 	b.WriteString("    s           Schedule settings\n")
 	b.WriteString("    /           Search\n")


### PR DESCRIPTION
## Summary
- **scan --json**: Added `--json` flag to `updater scan` for machine-readable output of discovered apps
- **TUI source filter**: Press `f` to cycle through source filters (sparkle → brew → github → mas → system → formula → electron → all)
- **Interactive notifications config**: Added `interactive_notifications` config option so launchd notifications use dialog mode without `--interactive` flag
- **CLI test coverage**: Added tests for policy command validation, config export/import roundtrip, config merge, and `cliSourceName` helper

## Test plan
- [x] `go vet ./...` clean
- [x] `go test -race -count=1 ./...` — all 11 packages pass
- [x] scan --json outputs valid JSON array
- [x] TUI source filter cycles correctly and filters visible apps
- [x] interactive_notifications config field serializes/deserializes
- [x] Policy, config, and check helper tests pass